### PR TITLE
Add support for PyPy

### DIFF
--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -43,6 +43,20 @@ INSTALL_SCHEMES = {
         'data'   : '$base',
         },
     'nt': WINDOWS_SCHEME,
+    'pypy': {
+        'purelib': '$base/site-packages',
+        'platlib': '$base/site-packages',
+        'headers': '$base/include/$dist_name',
+        'scripts': '$base/bin',
+        'data'   : '$base',
+        },
+    'pypy_nt': {
+        'purelib': '$base/site-packages',
+        'platlib': '$base/site-packages',
+        'headers': '$base/include/$dist_name',
+        'scripts': '$base/Scripts',
+        'data'   : '$base',
+        },
     }
 
 # user site schemes
@@ -455,6 +469,12 @@ class install(Command):
     def select_scheme(self, name):
         """Sets the install directories by applying the install schemes."""
         # it's the caller's problem if they supply a bad name!
+        if (hasattr(sys, 'pypy_version_info') and
+                not name.endswith(('_user', '_home'))):
+            if os.name == 'nt':
+                name = 'pypy_nt'
+            else:
+                name = 'pypy'
         scheme = INSTALL_SCHEMES[name]
         for key in SCHEME_KEYS:
             attrname = 'install_' + key

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -16,6 +16,8 @@ import sys
 
 from .errors import DistutilsPlatformError
 
+IS_PYPY = '__pypy__' in sys.builtin_module_names
+
 # These are needed in a couple of spots, so just compute them once.
 PREFIX = os.path.normpath(sys.prefix)
 EXEC_PREFIX = os.path.normpath(sys.exec_prefix)
@@ -97,7 +99,9 @@ def get_python_inc(plat_specific=0, prefix=None):
     """
     if prefix is None:
         prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
-    if os.name == "posix":
+    if IS_PYPY:
+        return os.path.join(prefix, 'include')
+    elif os.name == "posix":
         if python_build:
             # Assume the executable is in the build directory.  The
             # pyconfig.h file should be in the same directory.  Since

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -142,6 +142,14 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
     If 'prefix' is supplied, use it instead of sys.base_prefix or
     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
     """
+    if IS_PYPY:
+        # PyPy-specific schema
+        if prefix is None:
+            prefix = PREFIX
+        if standard_lib:
+            return os.path.join(prefix, "lib-python", sys.version[0])
+        return os.path.join(prefix, 'site-packages')
+
     if prefix is None:
         if standard_lib:
             prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
@@ -503,41 +511,42 @@ def get_config_vars(*args):
         _config_vars['prefix'] = PREFIX
         _config_vars['exec_prefix'] = EXEC_PREFIX
 
-        # For backward compatibility, see issue19555
-        SO = _config_vars.get('EXT_SUFFIX')
-        if SO is not None:
-            _config_vars['SO'] = SO
+        if not IS_PYPY:
+            # For backward compatibility, see issue19555
+            SO = _config_vars.get('EXT_SUFFIX')
+            if SO is not None:
+                _config_vars['SO'] = SO
 
-        # Always convert srcdir to an absolute path
-        srcdir = _config_vars.get('srcdir', project_base)
-        if os.name == 'posix':
-            if python_build:
-                # If srcdir is a relative path (typically '.' or '..')
-                # then it should be interpreted relative to the directory
-                # containing Makefile.
-                base = os.path.dirname(get_makefile_filename())
-                srcdir = os.path.join(base, srcdir)
-            else:
-                # srcdir is not meaningful since the installation is
-                # spread about the filesystem.  We choose the
-                # directory containing the Makefile since we know it
-                # exists.
-                srcdir = os.path.dirname(get_makefile_filename())
-        _config_vars['srcdir'] = os.path.abspath(os.path.normpath(srcdir))
+            # Always convert srcdir to an absolute path
+            srcdir = _config_vars.get('srcdir', project_base)
+            if os.name == 'posix':
+                if python_build:
+                    # If srcdir is a relative path (typically '.' or '..')
+                    # then it should be interpreted relative to the directory
+                    # containing Makefile.
+                    base = os.path.dirname(get_makefile_filename())
+                    srcdir = os.path.join(base, srcdir)
+                else:
+                    # srcdir is not meaningful since the installation is
+                    # spread about the filesystem.  We choose the
+                    # directory containing the Makefile since we know it
+                    # exists.
+                    srcdir = os.path.dirname(get_makefile_filename())
+            _config_vars['srcdir'] = os.path.abspath(os.path.normpath(srcdir))
 
-        # Convert srcdir into an absolute path if it appears necessary.
-        # Normally it is relative to the build directory.  However, during
-        # testing, for example, we might be running a non-installed python
-        # from a different directory.
-        if python_build and os.name == "posix":
-            base = project_base
-            if (not os.path.isabs(_config_vars['srcdir']) and
-                base != os.getcwd()):
-                # srcdir is relative and we are not in the same directory
-                # as the executable. Assume executable is in the build
-                # directory and make srcdir absolute.
-                srcdir = os.path.join(base, _config_vars['srcdir'])
-                _config_vars['srcdir'] = os.path.normpath(srcdir)
+            # Convert srcdir into an absolute path if it appears necessary.
+            # Normally it is relative to the build directory.  However, during
+            # testing, for example, we might be running a non-installed python
+            # from a different directory.
+            if python_build and os.name == "posix":
+                base = project_base
+                if (not os.path.isabs(_config_vars['srcdir']) and
+                    base != os.getcwd()):
+                    # srcdir is relative and we are not in the same directory
+                    # as the executable. Assume executable is in the build
+                    # directory and make srcdir absolute.
+                    srcdir = os.path.join(base, _config_vars['srcdir'])
+                    _config_vars['srcdir'] = os.path.normpath(srcdir)
 
         # OS X platforms require special customization to handle
         # multi-architecture, multi-os-version installers

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -45,6 +45,7 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertIsInstance(cvars, dict)
         self.assertTrue(cvars)
 
+    @unittest.skip('sysconfig.IS_PYPY')
     def test_srcdir(self):
         # See Issues #15322, #15364.
         srcdir = sysconfig.get_config_var('srcdir')

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -11,6 +11,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
     def setUp(self):
         self._backup_platform = sys.platform
         self._backup_get_config_var = sysconfig.get_config_var
+        self._backup_get_config_vars = sysconfig.get_config_vars
         class CompilerWrapper(UnixCCompiler):
             def rpath_foo(self):
                 return self.runtime_library_dir_option('/foo')
@@ -19,6 +20,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
     def tearDown(self):
         sys.platform = self._backup_platform
         sysconfig.get_config_var = self._backup_get_config_var
+        sysconfig.get_config_vars = self._backup_get_config_vars
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_runtime_libdir_option(self):
@@ -110,7 +112,13 @@ class UnixCCompilerTestCase(unittest.TestCase):
             if v == 'LDSHARED':
                 return 'gcc-4.2 -bundle -undefined dynamic_lookup '
             return 'gcc-4.2'
+
+        def gcvs(*args, _orig=sysconfig.get_config_vars):
+            if args:
+                return list(map(sysconfig.get_config_var, args))
+            return _orig()
         sysconfig.get_config_var = gcv
+        sysconfig.get_config_vars = gcvs
         with EnvironmentVarGuard() as env:
             env['CC'] = 'my_cc'
             del env['LDSHARED']
@@ -126,7 +134,13 @@ class UnixCCompilerTestCase(unittest.TestCase):
             if v == 'LDSHARED':
                 return 'gcc-4.2 -bundle -undefined dynamic_lookup '
             return 'gcc-4.2'
+
+        def gcvs(*args, _orig=sysconfig.get_config_vars):
+            if args:
+                return list(map(sysconfig.get_config_var, args))
+            return _orig()
         sysconfig.get_config_var = gcv
+        sysconfig.get_config_vars = gcvs
         with EnvironmentVarGuard() as env:
             env['CC'] = 'my_cc'
             env['LDSHARED'] = 'my_ld -bundle -dynamic'


### PR DESCRIPTION
Thanks to the work of @mattip in pypa/setuptools#2221, support for PyPy in distutils is coming along nicely. This branch cherry-picks the distutils-related commits from that PR and addresses other test-related failures. Now the tests are passing (or skipped) except for one on PyPy:

```
$ tox -e pypy3
pypy3 installed: attrs==19.3.0,cffi==1.14.0,greenlet==0.4.13,importlib-metadata==1.7.0,more-itertools==8.4.0,packaging==20.4,pluggy==0.13.1,py==1.9.0,pyparsing==2.4.7,pytest==5.4.3,readline==6.2.4.1,six==1.15.0,wcwidth==0.2.5,zipp==3.1.0
pypy3 run-test-pre: PYTHONHASHSEED='3646014116'
pypy3 run-test: commands[0] | pytest
============================= test session starts ==============================
platform darwin -- Python 3.6.9[pypy-7.3.1-final], pytest-5.4.3, py-1.9.0, pluggy-0.13.1
cachedir: .tox/pypy3/.pytest_cache
rootdir: /Users/jaraco/code/public/pypa/distutils, inifile: pytest.ini
collected 286 items

distutils/tests/test_archive_util.py ....................                [  6%]
distutils/tests/test_bdist.py ...                                        [  8%]
distutils/tests/test_bdist_dumb.py ..                                    [  8%]
distutils/tests/test_bdist_msi.py s.                                     [  9%]
distutils/tests/test_bdist_rpm.py ss.                                    [ 10%]
distutils/tests/test_bdist_wininst.py s.                                 [ 11%]
distutils/tests/test_build.py ..                                         [ 11%]
distutils/tests/test_build_clib.py ......                                [ 13%]
distutils/tests/test_build_ext.py s.............s..............          [ 24%]
distutils/tests/test_build_py.py .......                                 [ 26%]
distutils/tests/test_build_scripts.py ....                               [ 27%]
distutils/tests/test_check.py .s.ss.                                     [ 30%]
distutils/tests/test_clean.py ..                                         [ 30%]
distutils/tests/test_cmd.py ........                                     [ 33%]
distutils/tests/test_config.py ....                                      [ 34%]
distutils/tests/test_config_cmd.py .....                                 [ 36%]
distutils/tests/test_core.py ......                                      [ 38%]
distutils/tests/test_cygwinccompiler.py ....                             [ 40%]
distutils/tests/test_dep_util.py ....                                    [ 41%]
distutils/tests/test_dir_util.py ........                                [ 44%]
distutils/tests/test_dist.py ........s......................             [ 55%]
distutils/tests/test_extension.py ...                                    [ 56%]
distutils/tests/test_file_util.py ......                                 [ 58%]
distutils/tests/test_filelist.py .............                           [ 62%]
distutils/tests/test_install.py .....s..                                 [ 65%]
distutils/tests/test_install_data.py ..                                  [ 66%]
distutils/tests/test_install_headers.py ..                               [ 67%]
distutils/tests/test_install_lib.py ......                               [ 69%]
distutils/tests/test_install_scripts.py ...                              [ 70%]
distutils/tests/test_log.py ..                                           [ 70%]
distutils/tests/test_msvc9compiler.py ssss.                              [ 72%]
distutils/tests/test_msvccompiler.py ssss.                               [ 74%]
distutils/tests/test_register.py .....s..s.                              [ 77%]
distutils/tests/test_sdist.py ......s.........                           [ 83%]
distutils/tests/test_spawn.py ...                                        [ 84%]
distutils/tests/test_sysconfig.py ..........s.s..                        [ 89%]
distutils/tests/test_text_file.py ..                                     [ 90%]
distutils/tests/test_unixccompiler.py F...                               [ 91%]
distutils/tests/test_upload.py .......                                   [ 94%]
distutils/tests/test_util.py ...........                                 [ 98%]
distutils/tests/test_version.py ....                                     [ 99%]
distutils/tests/test_versionpredicate.py .                               [100%]

=================================== FAILURES ===================================
_____________ UnixCCompilerTestCase.test_osx_cc_overrides_ldshared _____________

self = <distutils.tests.test_unixccompiler.UnixCCompilerTestCase testMethod=test_osx_cc_overrides_ldshared>

    @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for OS X')
    def test_osx_cc_overrides_ldshared(self):
        # Issue #18080:
        # ensure that setting CC env variable also changes default linker
        def gcv(v):
            if v == 'LDSHARED':
                return 'gcc-4.2 -bundle -undefined dynamic_lookup '
            return 'gcc-4.2'
        sysconfig.get_config_var = gcv
        with EnvironmentVarGuard() as env:
            env['CC'] = 'my_cc'
            del env['LDSHARED']
            sysconfig.customize_compiler(self.cc)
>       self.assertEqual(self.cc.linker_so[0], 'my_cc')
E       AssertionError: 'gcc' != 'my_cc'
E       - gcc
E       + my_cc

distutils/tests/test_unixccompiler.py:118: AssertionError
=========================== short test summary info ============================
FAILED distutils/tests/test_unixccompiler.py::UnixCCompilerTestCase::test_osx_cc_overrides_ldshared
================== 1 failed, 261 passed, 24 skipped in 4.12s ===================
ERROR: InvocationError for command /Users/jaraco/code/public/pypa/distutils/.tox/pypy3/bin/pytest (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   pypy3: commands failed
```

Matti, can you suggest the right fix for this issue? Once I have the tests passing on PyPy3 here, I'll fold that into pypa/setuptools@distutils.