### PR TITLE
Support clang-cl on windows

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -207,11 +207,12 @@ class MSVCCompiler(CCompiler) :
     exe_extension = '.exe'
 
 
-    def __init__(self, verbose=0, dry_run=0, force=0):
+    def __init__(self, verbose=0, dry_run=0, force=0, use_clang_cl=False):
         CCompiler.__init__ (self, verbose, dry_run, force)
         # target platform (.plat_name is consistent with 'bdist')
         self.plat_name = None
         self.initialized = False
+        self.use_clang_cl = use_clang_cl
 
     def initialize(self, plat_name=None):
         # multi-init means we would need to check platform same each time...

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -968,6 +968,8 @@ compiler_class = { 'unix':    ('unixccompiler', 'UnixCCompiler',
                                "Mingw32 port of GNU C Compiler for Win32"),
                    'bcpp':    ('bcppcompiler', 'BCPPCompiler',
                                "Borland C++ Compiler"),
+                   'clang-cl':('_msvccompiler', 'ClangMSVCCompiler',
+                               "clang-cl for Microsoft Visual C++"),
                  }
 
 def show_compilers():


### PR DESCRIPTION
Credits to @zufuliu for the original patch.

To use clang-cl compiler, you can use

```
python setup.py build_ext --compiler=clang-cl
```

clang-cl is a compiler by the clang/LLVM team that is API compatible with the MSVC compiler cl and the object files created are ABI compatible with MSVC compiled objects. clang-cl by default uses the MSVC environment that is activated in the environment and finds the libraries from that MSVC environment. Reasons to use clang-cl is that it has more features than MSVC's cl, it is open source and it can be used from other platforms to cross-compile to windows.