### PR TITLE
Bugfix/tests for msvc spawn

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -15,7 +15,9 @@ for older versions in distutils.msvc9compiler and distutils.msvccompiler.
 
 import os
 import subprocess
-import winreg
+import contextlib
+with contextlib.suppress(ImportError):
+    import winreg
 
 from distutils.errors import DistutilsExecError, DistutilsPlatformError, \
                              CompileError, LibError, LinkError

--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -503,7 +503,7 @@ class MSVCCompiler(CCompiler) :
             log.debug("skipping %s (up-to-date)", output_filename)
 
     def spawn(self, cmd):
-        env = dict(os.environ, path=self._paths)
+        env = dict(os.environ, PATH=self._paths)
         return super().spawn(cmd, env=env)
 
     # -- Miscellaneous methods -----------------------------------------

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -906,8 +906,8 @@ int main (int argc, char **argv) {
     def execute(self, func, args, msg=None, level=1):
         execute(func, args, msg, self.dry_run)
 
-    def spawn(self, cmd):
-        spawn(cmd, dry_run=self.dry_run)
+    def spawn(self, cmd, **kwargs):
+        spawn(cmd, dry_run=self.dry_run, **kwargs)
 
     def move_file(self, src, dst):
         return move_file(src, dst, dry_run=self.dry_run)


### PR DESCRIPTION
In pypa/setuptools#2257, I learned that the test for the fix introduced in #6 was inadequate and that although the test did catch race conditions with the old implementation, it failed to catch a regression in the patched implementation. This approach goes further and ensures that the tests fail when the spawn command does not run as expected and then fixes two flaws in the implementation.