### PR TITLE
bpo-41882: Clean up after CCompiler.has_function()

### DIFF
--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -792,6 +792,8 @@ int main (int argc, char **argv) {
             objects = self.compile([fname], include_dirs=include_dirs)
         except CompileError:
             return False
+        finally:
+            os.remove(fname)
 
         try:
             self.link_executable(objects, "a.out",
@@ -799,6 +801,11 @@ int main (int argc, char **argv) {
                                  library_dirs=library_dirs)
         except (LinkError, TypeError):
             return False
+        else:
+            os.remove("a.out")
+        finally:
+            for fn in objects:
+                os.remove(fn)
         return True
 
     def find_library_file (self, dirs, lib, debug=0):


### PR DESCRIPTION
CCompiler.has_function() does not delete temporary files. Depending on the
check result it leaves temporary C source, object and executable files.
This PR fixes that.

https://bugs.python.org/issue41882
Closes #31