### PR TITLE
Use /O2 compiler option instead of /Ox for MSVC

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -248,7 +248,7 @@ class MSVCCompiler(CCompiler) :
         # Future releases of Python 3.x will include all past
         # versions of vcruntime*.dll for compatibility.
         self.compile_options = [
-            '/nologo', '/Ox', '/W3', '/GL', '/DNDEBUG', '/MD'
+            '/nologo', '/O2', '/W3', '/GL', '/DNDEBUG', '/MD'
         ]
 
         self.compile_options_debug = [

--- a/distutils/msvc9compiler.py
+++ b/distutils/msvc9compiler.py
@@ -399,13 +399,13 @@ class MSVCCompiler(CCompiler) :
 
         self.preprocess_options = None
         if self.__arch == "x86":
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3',
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3',
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3',
                                           '/Z7', '/D_DEBUG']
         else:
             # Win64
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3', '/GS-' ,
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3', '/GS-' ,
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/GS-',
                                           '/Z7', '/D_DEBUG']

--- a/distutils/msvccompiler.py
+++ b/distutils/msvccompiler.py
@@ -283,13 +283,13 @@ class MSVCCompiler(CCompiler) :
 
         self.preprocess_options = None
         if self.__arch == "Intel":
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3', '/GX' ,
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3', '/GX' ,
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/GX',
                                           '/Z7', '/D_DEBUG']
         else:
             # Win64
-            self.compile_options = [ '/nologo', '/Ox', '/MD', '/W3', '/GS-' ,
+            self.compile_options = [ '/nologo', '/O2', '/MD', '/W3', '/GS-' ,
                                      '/DNDEBUG']
             self.compile_options_debug = ['/nologo', '/Od', '/MDd', '/W3', '/GS-',
                                           '/Z7', '/D_DEBUG']


### PR DESCRIPTION
Compared to /Ox, /O2 has two additional options:

  /GF: Eliminate Duplicate Strings
  /Gy: Enable Function-Level Linking

Co-Authored-By: Nikita Kniazev <2743474+Kojoley@users.noreply.github.com>

https://github.com/pypa/distutils/issues/30