### PR TITLE
Fix finding headers when cross compiling

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -97,9 +97,9 @@ def get_python_inc(plat_specific=0, prefix=None):
     If 'prefix' is supplied, use it instead of sys.base_prefix or
     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
     """
-    if prefix is None:
-        prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
     if IS_PYPY:
+        if prefix is None:
+            prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
         return os.path.join(prefix, 'include')
     elif os.name == "posix":
         if python_build:
@@ -113,9 +113,17 @@ def get_python_inc(plat_specific=0, prefix=None):
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
                 return os.path.normpath(incdir)
-        python_dir = 'python' + get_python_version() + build_flags
-        return os.path.join(prefix, "include", python_dir)
+        if prefix is None:
+            if plat_specific:
+                return get_config_var('CONFINCLUDEPY')
+            else:
+                return get_config_var('INCLUDEPY')
+        else:
+            python_dir = 'python' + get_python_version() + build_flags
+            return os.path.join(prefix, "include", python_dir)
     elif os.name == "nt":
+        if prefix is None:
+            prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
         if python_build:
             # Include both the include and PC dir to ensure we can find
             # pyconfig.h


### PR DESCRIPTION
When cross-compiling extension modules using `build_ext`, `get_python_inc()` may be called to return the path to Python's headers. However, it uses the `sys.prefix` or `sys.exec_prefix` of the build Python, which returns incorrect paths when cross-compiling (paths pointing to build system headers).

To fix this, we use the `INCLUDEPY` and `CONFINCLUDEPY` conf variables, which can be configured to point at host Python by setting `_PYTHON_SYSCONFIGDATA_NAME`. The existing behavior is maintained on non-POSIX platforms or if a prefix is manually specified.

This was originally submitted to stdlib distutils as https://github.com/python/cpython/pull/22440, but unfortunately they are no longer accepting patches to it even though setuptools still uses stdlib distutils by default.

I tested this with the netifaces package, which compiles an extension module and fails with the following error if it is cross-compiled from x86_64 to armv7l without this patch, due to the word size difference:
```
  In file included from /nix/store/c84d97qz2x7yfaijcjwapvrnbwlkljs0-python3-3.8.7/include/python3.8/Python.h:63,
                   from netifaces.c:1:
  /nix/store/c84d97qz2x7yfaijcjwapvrnbwlkljs0-python3-3.8.7/include/python3.8/pyport.h:726:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
    726 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
        |  ^~~~~
  error: command 'armv6l-unknown-linux-gnueabihf-gcc' failed with exit status 1
```

After applying this patch and setting `_PYTHON_SYSCONFIGDATA_NAME` and `SETUPTOOLS_USE_DISTUTILS` appropriately, the build succeeds.

The stdlib distutils version of this patch is currently applied in nixpkgs (https://github.com/NixOS/nixpkgs/pull/98915) and we have not observed any breakage.
