### PR TITLE
Fixed get_export_symbols for unicode filenames

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -690,13 +690,15 @@ class build_ext(Command):
         provided, "PyInit_" + module_name.  Only relevant on Windows, where
         the .pyd file (DLL) must export the module "PyInit_" function.
         """
-        suffix = '_' + ext.name.split('.')[-1]
+        name = ext.name.split('.')[-1]
         try:
             # Unicode module name support as defined in PEP-489
             # https://www.python.org/dev/peps/pep-0489/#export-hook-name
-            suffix.encode('ascii')
+            name.encode('ascii')
         except UnicodeEncodeError:
-            suffix = 'U' + suffix.encode('punycode').replace(b'-', b'_').decode('ascii')
+            suffix = 'U_' + name.encode('punycode').replace(b'-', b'_').decode('ascii')
+        else:
+            suffix = "_" + name
 
         initfunc_name = "PyInit" + suffix
         if initfunc_name not in ext.export_symbols:

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -316,7 +316,7 @@ class BuildExtTestCase(TempdirManager,
         self.assertRegex(cmd.get_ext_filename(modules[0].name), r'foo(_d)?\..*')
         self.assertRegex(cmd.get_ext_filename(modules[1].name), r'föö(_d)?\..*')
         self.assertEqual(cmd.get_export_symbols(modules[0]), ['PyInit_foo'])
-        self.assertEqual(cmd.get_export_symbols(modules[1]), ['PyInitU_f_gkaa'])
+        self.assertEqual(cmd.get_export_symbols(modules[1]), ['PyInitU_f_1gaa'])
 
     def test_compiler_option(self):
         # cmd.compiler is an option and


### PR DESCRIPTION
The implementation of `get_export_symbols` from distutils doesn't quite conform to PEP-489
(because `"_<name>".encode('punycode') != "_" + ("<name>".encode('punycode'))`).
This affects the linking of unicode modules on Windows