### PR TITLE
Update msc_ver detection

### DIFF
--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -83,13 +83,13 @@ def get_msvcr():
             # VS2010 / MSVC 10.0
             return ['msvcr100']
         elif msc_ver == '1700':
-            # Visual Studio 2012 / Visual C++ 11.0
+            # VS2012 / MSVC 11.0
             return ['msvcr110']
         elif msc_ver == '1800':
-            # Visual Studio 2013 / Visual C++ 12.0
+            # VS2013 / MSVC 12.0
             return ['msvcr120']
         elif int(msc_ver) >= 1900 and int(msc_ver) < 2000:
-            # Visual Studio 2015 / Visual C++ 14.0
+            # VS2015 / MSVC 14.0
            return ['vcruntime140'] 
         else:
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -88,7 +88,7 @@ def get_msvcr():
         elif msc_ver == '1800':
             # VS2013 / MSVC 12.0
             return ['msvcr120']
-        elif int(msc_ver) >= 1900 and int(msc_ver) < 2000:
+        elif 1900 <= int(msc_ver) < 2000:
             # VS2015 / MSVC 14.0
            return ['ucrt', 'vcruntime140'] 
         else:

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -90,7 +90,7 @@ def get_msvcr():
             return ['msvcr120']
         elif int(msc_ver) >= 1900 and int(msc_ver) < 2000:
             # VS2015 / MSVC 14.0
-           return ['vcruntime140'] 
+           return ['ucrt', 'vcruntime140'] 
         else:
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -82,6 +82,15 @@ def get_msvcr():
         elif msc_ver == '1600':
             # VS2010 / MSVC 10.0
             return ['msvcr100']
+        elif msc_ver == '1700':
+            # Visual Studio 2012 / Visual C++ 11.0
+            return ['msvcr110']
+        elif msc_ver == '1800':
+            # Visual Studio 2013 / Visual C++ 12.0
+            return ['msvcr120']
+        elif int(msc_ver) >= 1900 and int(msc_ver) < 2000:
+            # Visual Studio 2015 / Visual C++ 14.0
+           return ['vcruntime140'] 
         else:
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 

--- a/distutils/tests/test_cygwinccompiler.py
+++ b/distutils/tests/test_cygwinccompiler.py
@@ -147,7 +147,7 @@ class CygwinCCompilerTestCase(support.TempdirManager,
 
         # unknown
         sys.version = ('2.5.1 (r251:54863, Apr 18 2007, 08:51:08) '
-                       '[MSC v.1999 32 bits (Intel)]')
+                       '[MSC v.2000 32 bits (Intel)]')
         self.assertRaises(ValueError, get_msvcr)
 
 def test_suite():

--- a/distutils/tests/test_cygwinccompiler.py
+++ b/distutils/tests/test_cygwinccompiler.py
@@ -141,6 +141,9 @@ class CygwinCCompilerTestCase(support.TempdirManager,
         sys.version = ('2.5.1 (r251:54863, Apr 18 2007, 08:51:08) '
                        '[MSC v.1500 32 bits (Intel)]')
         self.assertEqual(get_msvcr(), ['msvcr90'])
+        
+        sys.version = '3.10.0 (tags/v3.10.0:b494f59, Oct  4 2021, 18:46:30) [MSC v.1929 32 bit (Intel)]'
+        self.assertEqual(get_msvcr(), ['ucrt', 'vcruntime140'])
 
         # unknown
         sys.version = ('2.5.1 (r251:54863, Apr 18 2007, 08:51:08) '


### PR DESCRIPTION
See https://github.com/pypa/setuptools/discussions/2675

After checking the dependencies of those pyd in .whl built by MSVC and python39.dll through `objdump -p xxx.pyd | code -`, I personally think both ucrt and vcruntime140 should be specified.