### PR TITLE
sys._home -> sys.base_exec_prefix

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -202,9 +202,7 @@ class build_ext(Command):
             # Append the source distribution include and library directories,
             # this allows distutils on windows to work in the source tree
             self.include_dirs.append(os.path.dirname(get_config_h_filename()))
-            _sys_home = getattr(sys, '_home', None)
-            if _sys_home:
-                self.library_dirs.append(_sys_home)
+            self.library_dirs.append(sys.base_exec_prefix)
 
             # Use the .lib files for the correct architecture
             if self.plat_name == 'win32':


### PR DESCRIPTION
Facts:

* `library_dirs` is used to add `-L xxx` in build commands
* `sys._home` ~~only exists in venv~~ (https://github.com/python/cpython/blob/main/Lib/site.py#L527) It does exist outside of venv, but the value is None
* Last time it was changed in https://bugs.python.org/issue15367
* This change only applys to `os.name == 'nt'`

Problems:

* When using MS Store version of Python, include `sys._home` makes no sense. It's like `C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0` and only contains 0KB files
	![图片](https://user-images.githubusercontent.com/24759802/118432058-4596d180-b70a-11eb-918c-b680840b0a75.png)
* What's the point to include the folder only when in venv?

Changes:

* Always include base_exec_prefix

Other options:

* include it still only when in venv
* remove it, because right now it's not included outside of venv

Note:

* I don't know whether to choose `sys.base_exec_prefix` or `sys.base_prefix`, though they are identical in my environment.
