### PR TITLE
Prefer using `Distribution.has_ext_modules` method

### DIFF
--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -102,7 +102,7 @@ class build(Command):
         # particular module distribution -- if user didn't supply it, pick
         # one of 'build_purelib' or 'build_platlib'.
         if self.build_lib is None:
-            if self.distribution.ext_modules:
+            if self.distribution.has_ext_modules():
                 self.build_lib = self.build_platlib
             else:
                 self.build_lib = self.build_purelib

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -348,7 +348,7 @@ class install(Command):
         # module distribution is pure or not.  Of course, if the user
         # already specified install_lib, use their selection.
         if self.install_lib is None:
-            if self.distribution.ext_modules: # has extensions: non-pure
+            if self.distribution.has_ext_modules(): # has extensions: non-pure
                 self.install_lib = self.install_platlib
             else:
                 self.install_lib = self.install_purelib


### PR DESCRIPTION
This would allow downstream packages like [setuptools-rust](https://github.com/PyO3/setuptools-rust) to tell setuptools that the distribution has `ext_modules`, see https://github.com/PyO3/setuptools-rust/blob/75787159051f133f24dbceeb143ee5ae976c7244/setuptools_rust/setuptools_ext.py#L226-L229

Fixes https://github.com/PyO3/setuptools-rust/issues/146