### PR TITLE
Avoid symlink infinite loops (separate concerns + repro)

### DIFF
--- a/distutils/filelist.py
+++ b/distutils/filelist.py
@@ -255,19 +255,25 @@ def _find_all_simple(path):
     return filter(os.path.isfile, results)
 
 
+class UniqueDirs(set):
+    def __call__(self, item):
+        candidate = os.path.realpath(item)
+        result = candidate in self
+        self.add(candidate)
+        return not result
+
+
 def unique_dirs(items):
     """
     Given a walk result, remove any previously-seen dirs,
     avoiding infinite recursion.
     Ref https://bugs.python.org/issue44497.
     """
-    seen = set()
+    seen = UniqueDirs()
     for base, dirs, files in items:
-        real = os.path.realpath(base)
-        if real in seen:
+        if seen(base):
             del dirs[:]
             continue
-        seen.add(real)
         yield base, dirs, files
 
 

--- a/distutils/filelist.py
+++ b/distutils/filelist.py
@@ -249,10 +249,26 @@ def _find_all_simple(path):
     """
     results = (
         os.path.join(base, file)
-        for base, dirs, files in os.walk(path, followlinks=True)
+        for base, dirs, files in unique_dirs(os.walk(path, followlinks=True))
         for file in files
     )
     return filter(os.path.isfile, results)
+
+
+def unique_dirs(items):
+    """
+    Given a walk result, remove any previously-seen dirs,
+    avoiding infinite recursion.
+    Ref https://bugs.python.org/issue44497.
+    """
+    seen = set()
+    for base, dirs, files in items:
+        real = os.path.realpath(base)
+        if real in seen:
+            del dirs[:]
+            continue
+        seen.add(real)
+        yield base, dirs, files
 
 
 def findall(dir=os.curdir):

--- a/distutils/tests/test_filelist.py
+++ b/distutils/tests/test_filelist.py
@@ -331,6 +331,16 @@ class FindAllTestCase(unittest.TestCase):
             expected = [file1]
             self.assertEqual(filelist.findall(temp_dir), expected)
 
+    @os_helper.skip_unless_symlink
+    def test_symlink_loop(self):
+        with os_helper.temp_dir() as temp_dir:
+            link = os.path.join(temp_dir, 'link-to-parent')
+            content = os.path.join(temp_dir, 'somefile')
+            os_helper.create_empty_file(content)
+            os.symlink('.', link)
+            files = filelist.findall(temp_dir)
+            assert len(files) == 1
+
 
 def test_suite():
     return unittest.TestSuite([


### PR DESCRIPTION
- Add test capturing failure. Ref pypa/distutils#44.
- Ensure that the result contains only the one file, not all the different symlink variants to the same file.
- Wrap walk result to prevent infinite recursion. Fixes bpo-44497.
