### PR TITLE
adopt more standard schema for pypy3.8

### DIFF
--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -470,6 +470,7 @@ class install(Command):
         """Sets the install directories by applying the install schemes."""
         # it's the caller's problem if they supply a bad name!
         if (hasattr(sys, 'pypy_version_info') and
+                sys.version_info < (3, 8) and
                 not name.endswith(('_user', '_home'))):
             if os.name == 'nt':
                 name = 'pypy_nt'

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -100,11 +100,8 @@ def get_python_inc(plat_specific=0, prefix=None):
     if prefix is None:
         prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
     if os.name == "posix":
-        implementation = 'python'
-        if IS_PYPY:
-            if sys.version_info < (3, 8):
-                return os.path.join(prefix, 'include')
-            implementation = 'pypy'
+        if IS_PYPY and sys.version_info < (3, 8):
+            return os.path.join(prefix, 'include')
         if python_build:
             # Assume the executable is in the build directory.  The
             # pyconfig.h file should be in the same directory.  Since
@@ -116,6 +113,7 @@ def get_python_inc(plat_specific=0, prefix=None):
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
                 return os.path.normpath(incdir)
+        implementation = 'pypy' if IS_PYPY else 'python'
         python_dir = implementation + get_python_version() + build_flags
         return os.path.join(prefix, "include", python_dir)
     elif os.name == "nt":
@@ -146,16 +144,13 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
     """
     
-    implementation = 'python'
-    if IS_PYPY:
-        if sys.version_info < (3, 8):
-            # PyPy-specific schema
-            if prefix is None:
-                prefix = PREFIX
-            if standard_lib:
-                return os.path.join(prefix, "lib-python", sys.version[0])
-            return os.path.join(prefix, 'site-packages')
-        implementation = 'pypy'
+    if IS_PYPY and sys.version_info < (3, 8):
+        # PyPy-specific schema
+        if prefix is None:
+            prefix = PREFIX
+        if standard_lib:
+            return os.path.join(prefix, "lib-python", sys.version[0])
+        return os.path.join(prefix, 'site-packages')
 
     if prefix is None:
         if standard_lib:
@@ -171,6 +166,7 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
         else:
             # Pure Python
             libdir = "lib"
+        implementation = 'pypy' if IS_PYPY else 'python'
         libpython = os.path.join(prefix, libdir,
                                  implementation + get_python_version())
         if standard_lib:


### PR DESCRIPTION
PyPy 3.8 will use the standard posix schema as much as possible. In previous versions, downstream packagers like conda and linux distros had to patch this out anyway, this should make their lives easier. We cannot change the PyPy versions already released, so this is 3.8+ only. I intend to release PyPy 3.8 in a few weeks, so if this is correct it would be nice to get it out by then. 

In general, I think it would be beneficial to use the stdlib `sysconfig` where possible instead of repeating the code in `distutils.sysconfig`, it seems #23 is a step in this direction.

@mgorny, @isuruf