### PR TITLE
Prefer sysconfig.python_build

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -220,7 +220,7 @@ class build_ext(Command):
         # For extensions under Cygwin, Python's library directory must be
         # appended to library_dirs
         if sys.platform[:6] == 'cygwin':
-            if sys.executable.startswith(os.path.join(sys.exec_prefix, "bin")):
+            if not sysconfig.python_build:
                 # building third party extensions
                 self.library_dirs.append(os.path.join(sys.prefix, "lib",
                                                       "python" + get_python_version(),


### PR DESCRIPTION
Change the condition to `not sysconfig.python_build` to be consistent with
https://github.com/pypa/distutils/blob/aede9e035dde34b0f2a6e9fe3a3bd87d4b9d7370/distutils/command/build_ext.py#L235-L241

Cygwin maintainers: Is this behaviorally correct?