### PR TITLE
override ldshared on non-macos platforms too if CC is overriden

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -214,10 +214,9 @@ def customize_compiler(compiler):
 
         if 'CC' in os.environ:
             newcc = os.environ['CC']
-            if (sys.platform == 'darwin'
-                    and 'LDSHARED' not in os.environ
+            if('LDSHARED' not in os.environ
                     and ldshared.startswith(cc)):
-                # On OS X, if CC is overridden, use that as the default
+                # If CC is overridden, use that as the default
                 #       command for LDSHARED as well
                 ldshared = newcc + ldshared[len(cc):]
             cc = newcc

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -181,8 +181,8 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sysconfig.get_config_var = gcv
         self.assertEqual(self.cc.rpath_foo(), '-R/foo')
 
-    @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for OS X')
-    def test_osx_cc_overrides_ldshared(self):
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    def test_cc_overrides_ldshared(self):
         # Issue #18080:
         # ensure that setting CC env variable also changes default linker
         def gcv(v):
@@ -202,8 +202,8 @@ class UnixCCompilerTestCase(unittest.TestCase):
             sysconfig.customize_compiler(self.cc)
         self.assertEqual(self.cc.linker_so[0], 'my_cc')
 
-    @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for OS X')
-    def test_osx_explicit_ldshared(self):
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    def test_explicit_ldshared(self):
         # Issue #18080:
         # ensure that setting CC env variable does not change
         #   explicit LDSHARED setting for linker


### PR DESCRIPTION
I don't know why this was enabled only for macos.
If CC is overriden, then LDSHARED should be overriden to use the same compiler,
otherwise, the compiler used in the compile phase and link phase will be two
different compilers.

cc @FFY00 