### PR TITLE
Use -Wl,-R instead of -R

### DIFF
--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -177,7 +177,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
             elif v == 'GNULD':
                 return 'yes'
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-R/foo')
+        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
 
         # non-GCC non-GNULD
         sys.platform = 'bar'
@@ -187,7 +187,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
             elif v == 'GNULD':
                 return 'no'
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-R/foo')
+        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_cc_overrides_ldshared(self):

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -177,7 +177,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
             elif v == 'GNULD':
                 return 'yes'
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
+        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
 
         # non-GCC non-GNULD
         sys.platform = 'bar'

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -261,7 +261,7 @@ class UnixCCompiler(CCompiler):
                 # No idea how --enable-new-dtags would be passed on to
                 # ld if this system was using GNU ld.  Don't know if a
                 # system like this even exists.
-                return "-R" + dir
+                return "-Wl,-R" + dir
 
     def library_option(self, lib):
         return "-l" + lib

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -246,21 +246,16 @@ class UnixCCompiler(CCompiler):
                 return ["-Wl,+s", "-L" + dir]
             return ["+s", "-L" + dir]
         else:
-            if self._is_gcc(compiler):
-                # gcc on non-GNU systems does not need -Wl, but can
-                # use it anyway.  Since distutils has always passed in
-                # -Wl whenever gcc was used in the past it is probably
-                # safest to keep doing so.
-                if sysconfig.get_config_var("GNULD") == "yes":
-                    # GNU ld needs an extra option to get a RUNPATH
-                    # instead of just an RPATH.
-                    return "-Wl,--enable-new-dtags,-R" + dir
-                else:
-                    return "-Wl,-R" + dir
+            # gcc on non-GNU systems does not need -Wl, but can
+            # use it anyway. for all compilers including gcc we assume that
+            # -Wl is the way to pass a compiler option to the linker
+            # and for all linkers we assume that -R is the way to set
+            # an rpath.
+            if sysconfig.get_config_var("GNULD") == "yes":
+                # GNU ld needs an extra option to get a RUNPATH
+                # instead of just an RPATH.
+                return "-Wl,--enable-new-dtags,-R" + dir
             else:
-                # No idea how --enable-new-dtags would be passed on to
-                # ld if this system was using GNU ld.  Don't know if a
-                # system like this even exists.
                 return "-Wl,-R" + dir
 
     def library_option(self, lib):


### PR DESCRIPTION
Sometimes _is_gcc will fail to identify a compiler as gcc
or sometimes there are compilers that act like gcc with different
names.

Since all platforms that support -R directly supports -Wl,-R,
using -Wl,-R should support more use cases