### PR TITLE
make GCC version regex more specific

### DIFF
--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -377,7 +377,7 @@ def check_config_h():
         return (CONFIG_H_UNCERTAIN,
                 "couldn't read '%s': %s" % (fn, exc.strerror))
 
-RE_VERSION = re.compile(br'(\d+\.\d+(\.\d+)*)')
+RE_VERSION = re.compile(br'[\D\s]*(\d+\.\d+(\.\d+)*)[\D\s]*$')
 
 def _find_exe_version(cmd):
     """Find the version of an executable by running `cmd` in the shell.

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -377,7 +377,7 @@ def check_config_h():
         return (CONFIG_H_UNCERTAIN,
                 "couldn't read '%s': %s" % (fn, exc.strerror))
 
-RE_VERSION = re.compile(br'[\D\s]*(\d+\.\d+(\.\d+)*)[\D\s]*$')
+RE_VERSION = re.compile(br'[\D\s]*(\d+\.\d+(\.\d+)*)[\D\s]*')
 
 def _find_exe_version(cmd):
     """Find the version of an executable by running `cmd` in the shell.


### PR DESCRIPTION
allowing also uncommon version identifiers to be matched correctly

Note: I've originally found a problem with the regex when working on https://github.com/msys2/MINGW-packages/pull/8353.
As this was half a year ago (the main issue that PR tackled is now solved differently so no need to fix that) I can't remember the details where the old one failed - please inspect the regex change and consider it when it works "as good as the old one" (I'm quite sure I've tested that back then).

Thank you!