### PR TITLE
CCompiler.has_function: Do not fail if self.outputdir is set

### DIFF
--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -802,7 +802,10 @@ int main (int argc, char **argv) {
         except (LinkError, TypeError):
             return False
         else:
-            os.remove("a.out")
+            output_dir = self.output_dir
+            if output_dir is None:
+                output_dir = ''
+            os.remove(os.path.join(output_dir, "a.out"))
         finally:
             for fn in objects:
                 os.remove(fn)

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -802,10 +802,7 @@ int main (int argc, char **argv) {
         except (LinkError, TypeError):
             return False
         else:
-            output_dir = self.output_dir
-            if output_dir is None:
-                output_dir = ''
-            os.remove(os.path.join(output_dir, "a.out"))
+            os.remove(os.path.join(self.output_dir or '', "a.out"))
         finally:
             for fn in objects:
                 os.remove(fn)

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -232,6 +232,13 @@ class UnixCCompilerTestCase(unittest.TestCase):
             sysconfig.customize_compiler(self.cc)
         self.assertEqual(self.cc.linker_so[0], 'my_ld')
 
+    def test_has_function(self):
+        # Issue https://github.com/pypa/distutils/issues/64:
+        # ensure that setting output_dir does not raise
+        # FileNotFoundError: [Errno 2] No such file or directory: 'a.out'
+        self.cc.output_dir = 'scratch'
+        self.cc.has_function('abort', includes=['stdlib.h'])
+
 
 def test_suite():
     return unittest.makeSuite(UnixCCompilerTestCase)


### PR DESCRIPTION
Previously submitted as https://github.com/pypa/setuptools/pull/2860

Fixes #64 