### PR TITLE
Update `distutils.core.setup/run_setup` to better match `setuptools.build_meta`.

### DIFF
--- a/distutils/core.py
+++ b/distutils/core.py
@@ -224,9 +224,8 @@ def run_setup (script_name, script_args=None, stop_after="run"):
             sys.argv[0] = script_name
             if script_args is not None:
                 sys.argv[1:] = script_args
-            _open = getattr(tokenize, 'open', open)
-            # ^-- tokenize.open supports automatic encoding detection
-            with _open(script_name) as f:
+            # tokenize.open supports automatic encoding detection
+            with tokenize.open(script_name) as f:
                 code = f.read().replace(r'\r\n', r'\n')
                 exec(code, g)
         finally:

--- a/distutils/core.py
+++ b/distutils/core.py
@@ -143,29 +143,39 @@ def setup (**attrs):
     if _setup_stop_after == "commandline":
         return dist
 
-    # And finally, run all the commands found on the command line.
     if ok:
-        try:
-            dist.run_commands()
-        except KeyboardInterrupt:
-            raise SystemExit("interrupted")
-        except OSError as exc:
-            if DEBUG:
-                sys.stderr.write("error: %s\n" % (exc,))
-                raise
-            else:
-                raise SystemExit("error: %s" % (exc,))
-
-        except (DistutilsError,
-                CCompilerError) as msg:
-            if DEBUG:
-                raise
-            else:
-                raise SystemExit("error: " + str(msg))
-
-    return dist
+        return run_commands(dist)
 
 # setup ()
+
+
+def run_commands (dist):
+    """Given a Distribution object run all the commands,
+    raising ``SystemExit`` errors in the case of failure.
+
+    This function assumes that either ``sys.argv`` or ``dist.script_args``
+    is already set accordingly.
+    """
+    # And finally, run all the commands found on the command line.
+    try:
+        dist.run_commands()
+    except KeyboardInterrupt:
+        raise SystemExit("interrupted")
+    except OSError as exc:
+        if DEBUG:
+            sys.stderr.write("error: %s\n" % (exc,))
+            raise
+        else:
+            raise SystemExit("error: %s" % (exc,))
+
+    except (DistutilsError,
+            CCompilerError) as msg:
+        if DEBUG:
+            raise
+        else:
+            raise SystemExit("error: " + str(msg))
+
+    return dist
 
 
 def run_setup (script_name, script_args=None, stop_after="run"):

--- a/distutils/core.py
+++ b/distutils/core.py
@@ -143,6 +143,7 @@ def setup (**attrs):
     if _setup_stop_after == "commandline":
         return dist
 
+    # And finally, run all the commands found on the command line.
     if ok:
         return run_commands(dist)
 
@@ -158,7 +159,6 @@ def run_commands (dist):
     This function assumes that either ``sys.argv`` or ``dist.script_args``
     is already set accordingly.
     """
-    # And finally, run all the commands found on the command line.
     try:
         dist.run_commands()
     except KeyboardInterrupt:

--- a/distutils/core.py
+++ b/distutils/core.py
@@ -146,6 +146,8 @@ def setup (**attrs):
     if ok:
         return run_commands(dist)
 
+    return dist
+
 # setup ()
 
 

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -168,10 +168,6 @@ Common commands: (see '--help-commands' for more)
         # for the setup script to override command classes
         self.cmdclass = {}
 
-        # Make sure 'commands' is defined, so dist.run_commands can run
-        # It might be overwritten by parse_command_line()
-        self.commands = []
-
         # 'command_packages' is a list of packages in which commands
         # are searched for.  The factory for command 'foo' is expected
         # to be named 'foo' in the module 'foo' in one of the packages

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -168,6 +168,10 @@ Common commands: (see '--help-commands' for more)
         # for the setup script to override command classes
         self.cmdclass = {}
 
+        # Make sure 'commands' is defined, so dist.run_commands can run
+        # It might be overwritten by parse_command_line()
+        self.commands = []
+
         # 'command_packages' is a list of packages in which commands
         # are searched for.  The factory for command 'foo' is expected
         # to be named 'foo' in the module 'foo' in one of the packages

--- a/distutils/tests/test_core.py
+++ b/distutils/tests/test_core.py
@@ -10,6 +10,7 @@ from . import py38compat as os_helper
 import unittest
 from distutils.tests import support
 from distutils import log
+from distutils.dist import Distribution
 
 # setup script that uses __file__
 setup_using___file__ = """\
@@ -43,6 +44,16 @@ class install(_install):
     sub_commands = _install.sub_commands + ['cmd']
 
 setup(cmdclass={'install': install})
+"""
+
+setup_within_if_main = """\
+from distutils.core import setup
+
+def main():
+    return setup(name="setup_within_if_main")
+
+if __name__ == "__main__":
+    main()
 """
 
 class CoreTestCase(support.EnvironGuard, unittest.TestCase):
@@ -114,6 +125,12 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         if output.endswith("\n"):
             output = output[:-1]
         self.assertEqual(cwd, output)
+
+    def test_run_setup_within_if_main(self):
+        dist = distutils.core.run_setup(
+            self.write_setup(setup_within_if_main), stop_after="config")
+        self.assertIsInstance(dist, Distribution)
+        self.assertEqual(dist.get_name(), "setup_within_if_main")
 
     def test_debug_mode(self):
         # this covers the code called when DEBUG is set

--- a/distutils/tests/test_core.py
+++ b/distutils/tests/test_core.py
@@ -132,6 +132,14 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertIsInstance(dist, Distribution)
         self.assertEqual(dist.get_name(), "setup_within_if_main")
 
+    def test_run_commands(self):
+        sys.argv = ['setup.py', 'build']
+        dist = distutils.core.run_setup(
+            self.write_setup(setup_within_if_main), stop_after="commandline")
+        self.assertNotIn('build', dist.have_run)
+        distutils.core.run_commands(dist)
+        self.assertIn('build', dist.have_run)
+
     def test_debug_mode(self):
         # this covers the code called when DEBUG is set
         sys.argv = ['setup.py', '--name']


### PR DESCRIPTION
## Motivation

I noticed that [`setuptools.build_meta`](https://github.com/pypa/setuptools/blob/413357393b74acd7f8bd02075a0f7ce8c239b869/setuptools/build_meta.py#L149-L158) "re-implements" the `run_setup` function (there are differences between the 2 functions, e.g. `distutils.core.run_setup` wraps the code in a `try...except`, but the main idea behind both look similar to me).

There is one major difference: `setuptools` use `tokenize.open` and replaces `\r\n` with `\n`.
I went through setuptools commit history but did not find any comments/commit messages explaining exactly why, but I assume that it [improves encoding detection](https://docs.python.org/3/library/tokenize.html?highlight=tokenize#tokenize.open).

My intention with this PR is to update the `distutils` code using the same technique as used in `setuptools`, so eventually the same function could be used.

## Changes

- Use the same `tokenize.open` technique as employed by `setuptools.build_meta` in `distutils.core.run_setup`.
- Additionally, I refactored the origin `setup` function and split out `run_commands`, this way, one can use `dist = run_setup("setup.py", stop_after="config")` to get the configuration and later run `run_commands(dist)`.
- I also added some tests.

### Side note

In terms of implications for `setuptools`, I imagine that eventually we could build the "new-static-config-style" distribution objects directly from the `setup.cfg`/`pyproject.toml` and then run them with `run_commands`, instead of always creating a `setup.py` stub.

Similarly, when `setup.py` is found, `dist = run_setup("setup.py", stop_after="config")` could be used to obtain the `dist` object and then revert to the same flow as a `setup.cfg`/`pyproject.toml`-only project...

(Basically a change in the mental model, instead of making `setup.cfg`/`pyproject.toml` use the same flow as `setup.py` one, we can make a `setup.py` use the same flow as `setup.cfg`).

