### PR TITLE
cygwinccompiler: Split CC env var before passing to subprocess

### DIFF
--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -50,6 +50,7 @@ cygwin in no-cygwin mode).
 import os
 import sys
 import copy
+import shlex
 from subprocess import Popen, PIPE, check_output
 import re
 
@@ -421,5 +422,5 @@ def get_versions():
 
 def is_cygwincc(cc):
     '''Try to determine if the compiler that would be used is from cygwin.'''
-    out_string = check_output([cc, '-dumpmachine'])
+    out_string = check_output(shlex.split(cc) + ['-dumpmachine'])
     return out_string.strip().endswith(b'cygwin')


### PR DESCRIPTION
4113bc31a8e62 added support for clang by respecting the CC env variable.
The content of the env var gets passed to check_output() as the compiler
executable. But CC is not just a path to an executable but a command line,
such as "ccache gcc" which makes checkout_output() fail in those cases because
it will try to look for "ccache gcc" in PATH instead of "ccache".

To fix the issue use shlex to parse the command line before passing it to
check_output().

Co-authored-by:  Christoph Reiter <reiter.christoph@gmail.com>
Signed-off-by: Naveen M K <naveen521kk@gmail.com>

Part of #34