### PR TITLE
msvc9compiler: Don't raise DistutilsPlatformError on import

### DIFF
--- a/distutils/msvc9compiler.py
+++ b/distutils/msvc9compiler.py
@@ -291,8 +291,6 @@ def query_vcvarsall(version, arch="x86"):
 
 # More globals
 VERSION = get_build_version()
-if VERSION < 8.0:
-    raise DistutilsPlatformError("VC %0.1f is not supported by this module" % VERSION)
 # MACROS = MacroExpander(VERSION)
 
 class MSVCCompiler(CCompiler) :
@@ -339,6 +337,8 @@ class MSVCCompiler(CCompiler) :
     def initialize(self, plat_name=None):
         # multi-init means we would need to check platform same each time...
         assert not self.initialized, "don't init multiple times"
+        if self.__version < 8.0:
+            raise DistutilsPlatformError("VC %0.1f is not supported by this module" % self.__version)
         if plat_name is None:
             plat_name = get_platform()
         # sanity check for platforms to prevent obscure errors later.


### PR DESCRIPTION
It gets raised when get_build_version() returns a too low version
or when it fails to detect a MSVC version, which for exaple is the
case when CPython is built with gcc/clang.

In theory this module isn't needed on non-MSVC platforms, but setuptools
imports it anyway when monkey patching, which in turn makes setuptools fail.

To work around this only check the version when initialising MSVCCompiler().

This also mirrors the behaviour of the newer MSVCCompiler() (in _msvccompiler)
which also raises DistutilsPlatformError() only on initialisation in case
it can't find the right MSVC.

Part of #34