### PR TITLE
CI: Add a test job for Cygwin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,30 @@ jobs:
       - name: Run tests
         run: tox
 
+  test_cygwin:
+    strategy:
+      matrix:
+        python: [39]
+        platform: [windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@v1
+        with:
+          platform: x86_64
+          packages: >-
+            python${{ matrix.python }},
+            python${{ matrix.python }}-devel,
+            python${{ matrix.python }}-pytest,
+            gcc-core,
+            gcc-g++,
+            ncompress
+      - name: Run tests
+        shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -leo pipefail -o igncr {0}
+        run: |
+          pytest -rs
+
   ci_setuptools:
     # Integration testing with setuptools
     strategy:

--- a/distutils/tests/test_archive_util.py
+++ b/distutils/tests/test_archive_util.py
@@ -339,7 +339,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
     def test_make_archive_owner_group(self):
         # testing make_archive with owner and group, with various combinations
         # this works even if there's not gid/uid support
-        if UID_GID_SUPPORT:
+        if UID_GID_SUPPORT and sys.platform != "cygwin":
             group = grp.getgrgid(0)[0]
             owner = pwd.getpwuid(0)[0]
         else:
@@ -365,6 +365,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
 
     @unittest.skipUnless(ZLIB_SUPPORT, "Requires zlib")
     @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
+    @unittest.skipUnless(sys.platform != "cygwin", "Cygwin doesn't have UID=0")
     def test_tarfile_root_owner(self):
         tmpdir =  self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')

--- a/distutils/tests/test_archive_util.py
+++ b/distutils/tests/test_archive_util.py
@@ -14,16 +14,11 @@ from distutils.archive_util import (check_archive_formats, make_tarball,
 from distutils.spawn import find_executable, spawn
 from distutils.tests import support
 from test.support import run_unittest, patch
+from .unix_compat import require_unix_id, require_uid_0, grp, pwd, UID_0_SUPPORT
 
 from .py38compat import change_cwd
 from .py38compat import check_warnings
 
-try:
-    import grp
-    import pwd
-    UID_GID_SUPPORT = True
-except ImportError:
-    UID_GID_SUPPORT = False
 
 try:
     import zipfile
@@ -339,7 +334,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
     def test_make_archive_owner_group(self):
         # testing make_archive with owner and group, with various combinations
         # this works even if there's not gid/uid support
-        if UID_GID_SUPPORT and sys.platform != "cygwin":
+        if UID_0_SUPPORT:
             group = grp.getgrgid(0)[0]
             owner = pwd.getpwuid(0)[0]
         else:
@@ -364,8 +359,8 @@ class ArchiveUtilTestCase(support.TempdirManager,
         self.assertTrue(os.path.exists(res))
 
     @unittest.skipUnless(ZLIB_SUPPORT, "Requires zlib")
-    @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
-    @unittest.skipUnless(sys.platform != "cygwin", "Cygwin doesn't have UID=0")
+    @require_unix_id
+    @require_uid_0
     def test_tarfile_root_owner(self):
         tmpdir =  self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')

--- a/distutils/tests/test_sdist.py
+++ b/distutils/tests/test_sdist.py
@@ -1,5 +1,6 @@
 """Tests for distutils.command.sdist."""
 import os
+import sys
 import tarfile
 import unittest
 import warnings
@@ -441,6 +442,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
 
     @unittest.skipUnless(ZLIB_SUPPORT, "requires zlib")
     @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
+    @unittest.skipUnless(sys.platform != "cygwin", "Cygwin doesn't have UID=0")
     @unittest.skipIf(find_executable('tar') is None,
                      "The tar command is not found")
     @unittest.skipIf(find_executable('gzip') is None,

--- a/distutils/tests/test_sdist.py
+++ b/distutils/tests/test_sdist.py
@@ -1,6 +1,5 @@
 """Tests for distutils.command.sdist."""
 import os
-import sys
 import tarfile
 import unittest
 import warnings
@@ -8,6 +7,7 @@ import zipfile
 from os.path import join
 from textwrap import dedent
 from test.support import captured_stdout, run_unittest
+from .unix_compat import require_unix_id, require_uid_0, pwd, grp
 
 from .py38compat import check_warnings
 
@@ -16,13 +16,6 @@ try:
     ZLIB_SUPPORT = True
 except ImportError:
     ZLIB_SUPPORT = False
-
-try:
-    import grp
-    import pwd
-    UID_GID_SUPPORT = True
-except ImportError:
-    UID_GID_SUPPORT = False
 
 from distutils.command.sdist import sdist, show_formats
 from distutils.core import Distribution
@@ -441,8 +434,8 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
                                              'fake-1.0/README.manual'])
 
     @unittest.skipUnless(ZLIB_SUPPORT, "requires zlib")
-    @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
-    @unittest.skipUnless(sys.platform != "cygwin", "Cygwin doesn't have UID=0")
+    @require_unix_id
+    @require_uid_0
     @unittest.skipIf(find_executable('tar') is None,
                      "The tar command is not found")
     @unittest.skipIf(find_executable('gzip') is None,

--- a/distutils/tests/unix_compat.py
+++ b/distutils/tests/unix_compat.py
@@ -1,0 +1,16 @@
+import sys
+import unittest
+
+try:
+    import grp
+    import pwd
+except ImportError:
+    grp = pwd = None
+
+
+UNIX_ID_SUPPORT = grp and pwd
+UID_0_SUPPORT = UNIX_ID_SUPPORT and sys.platform != "cygwin"
+
+require_unix_id = unittest.skipUnless(
+    UNIX_ID_SUPPORT, "Requires grp and pwd support")
+require_uid_0 = unittest.skipUnless(UID_0_SUPPORT, "Requires UID 0 support")


### PR DESCRIPTION
I'm not a Cygwin developer, but since the MSYS2 patches are touching Cygwin code paths this could be helpful in preventing regressions in that area.

Example run on my fork: https://github.com/lazka/distutils/runs/4569103775?check_suite_focus=true