### PR TITLE
Fix spawn fallback

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -527,7 +527,7 @@ class MSVCCompiler(CCompiler) :
             return
         warnings.warn(
             "Fallback spawn triggered. Please update distutils monkeypatch.")
-        with unittest.mock.patch('os.environ', env):
+        with unittest.mock.patch.dict('os.environ', env):
             bag.value = super().spawn(cmd)
 
     # -- Miscellaneous methods -----------------------------------------


### PR DESCRIPTION
Note that using unittest.mock doesn't fix the env in the subprocess.

For eg:
```python
import unittest.mock
import os
import subprocess
with unittest.mock.patch('os.environ', {"FOO": "bar"}):
     print(os.environ["FOO"])
     subprocess.check_call("echo FOO=$FOO", shell=True)
```
outputs
```
bar
FOO=
```