### PR TITLE
sysconfig: use get_config_h_filename() from the stdlib

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -13,6 +13,7 @@ import _imp
 import os
 import re
 import sys
+import sysconfig
 
 from .errors import DistutilsPlatformError
 
@@ -274,10 +275,10 @@ def get_config_h_filename():
             inc_dir = os.path.join(_sys_home or project_base, "PC")
         else:
             inc_dir = _sys_home or project_base
+        return os.path.join(inc_dir, 'pyconfig.h')
     else:
-        inc_dir = get_python_inc(plat_specific=1)
+        return sysconfig.get_config_h_filename()
 
-    return os.path.join(inc_dir, 'pyconfig.h')
 
 
 # Allow this value to be patched by pkgsrc. Ref pypa/distutils#16.


### PR DESCRIPTION
distutils.sysconfig provides various functions already present in
the stdlib sysconfig module.

Reusing the stdlib versions has the advantage that it is in control of
the Python distributor/packager and distutils doesn't have to deal with
platform details.

This tries to start the transition using the simple get_config_h_filename()
for starters by forwarding calls to the stdlib in case Python is
considered to be installed.