### PR TITLE
sysconfig: use get_makefile_filename() from stdlib sysconfig

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -281,25 +281,9 @@ def get_config_h_filename():
 
 
 
-# Allow this value to be patched by pkgsrc. Ref pypa/distutils#16.
-_makefile_tmpl = 'config-{python_ver}{build_flags}{multiarch}'
-
-
 def get_makefile_filename():
     """Return full pathname of installed Makefile from the Python build."""
-    if python_build:
-        return os.path.join(_sys_home or project_base, "Makefile")
-    lib_dir = get_python_lib(plat_specific=0, standard_lib=1)
-    multiarch = (
-        '-%s' % sys.implementation._multiarch
-        if hasattr(sys.implementation, '_multiarch') else ''
-    )
-    config_file = _makefile_tmpl.format(
-        python_ver=get_python_version(),
-        build_flags=build_flags,
-        multiarch=multiarch,
-    )
-    return os.path.join(lib_dir, config_file, 'Makefile')
+    return sysconfig.get_makefile_filename()
 
 
 def parse_config_h(fp, g=None):

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -38,6 +38,12 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         config_h = sysconfig.get_config_h_filename()
         self.assertTrue(os.path.isfile(config_h), config_h)
 
+    @unittest.skipIf(sys.platform == 'win32',
+                     'Makefile only exists on Unix like systems')
+    def test_get_makefile_filename(self):
+        makefile = sysconfig.get_makefile_filename()
+        self.assertTrue(os.path.isfile(makefile), makefile)
+
     def test_get_python_lib(self):
         # XXX doesn't work on Linux when Python was never installed before
         #self.assertTrue(os.path.isdir(lib_dir), lib_dir)


### PR DESCRIPTION
Instead of guessing the filename just refer to the stdlib.

This also removes the "_makefile_tmpl" hook added in pypa#16, but

1) It was never implemented by the distro requesting it from what I can see:
   https://github.com/NetBSD/pkgsrc/blob/586097714897b1b4d4a9/devel/py-setuptools/Makefile#L28
2) The stdlib version should return a proper result as it is patched by the distro requesting the change:
   https://github.com/NetBSD/pkgsrc/blob/6efa5763ec447864a7d4/lang/python38/patches/patch-Lib_sysconfig.py

Also adds a small test checking that the file exists on Unix platforms