### PR TITLE
sysconfig: use parse_config_h() from stdlib sysconfig

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -13,6 +13,7 @@ import _imp
 import os
 import re
 import sys
+import sysconfig
 
 from .errors import DistutilsPlatformError
 
@@ -308,26 +309,7 @@ def parse_config_h(fp, g=None):
     optional dictionary is passed in as the second argument, it is
     used instead of a new dictionary.
     """
-    if g is None:
-        g = {}
-    define_rx = re.compile("#define ([A-Z][A-Za-z0-9_]+) (.*)\n")
-    undef_rx = re.compile("/[*] #undef ([A-Z][A-Za-z0-9_]+) [*]/\n")
-    #
-    while True:
-        line = fp.readline()
-        if not line:
-            break
-        m = define_rx.match(line)
-        if m:
-            n, v = m.group(1, 2)
-            try: v = int(v)
-            except ValueError: pass
-            g[n] = v
-        else:
-            m = undef_rx.match(line)
-            if m:
-                g[m.group(1)] = 0
-    return g
+    return sysconfig.parse_config_h(fp, vars=g)
 
 
 # Regexes needed for parsing Makefile (and similar syntaxes,

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -283,6 +283,16 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         outs, errs = p.communicate()
         self.assertEqual(0, p.returncode, "Subprocess failed: " + outs)
 
+    def test_parse_config_h(self):
+        config_h = sysconfig.get_config_h_filename()
+        input = {}
+        with open(config_h, encoding="utf-8") as f:
+            result = sysconfig.parse_config_h(f, g=input)
+        self.assertTrue(input)
+        self.assertTrue(input is result)
+        with open(config_h, encoding="utf-8") as f:
+            result = sysconfig.parse_config_h(f)
+        self.assertTrue(result)
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
The only difference is the argument name change