### PR TITLE
tests: use loadTestsFromTestCase() instead of the deprecated makeSuite()

### DIFF
--- a/distutils/tests/test_archive_util.py
+++ b/distutils/tests/test_archive_util.py
@@ -387,7 +387,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
             archive.close()
 
 def test_suite():
-    return unittest.makeSuite(ArchiveUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(ArchiveUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_bdist.py
+++ b/distutils/tests/test_bdist.py
@@ -51,7 +51,7 @@ class BuildTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(BuildTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_bdist_dumb.py
+++ b/distutils/tests/test_bdist_dumb.py
@@ -91,7 +91,7 @@ class BuildDumbTestCase(support.TempdirManager,
         self.assertEqual(contents, sorted(wanted))
 
 def test_suite():
-    return unittest.makeSuite(BuildDumbTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildDumbTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_bdist_msi.py
+++ b/distutils/tests/test_bdist_msi.py
@@ -22,7 +22,7 @@ class BDistMSITestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(BDistMSITestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BDistMSITestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_bdist_rpm.py
+++ b/distutils/tests/test_bdist_rpm.py
@@ -129,7 +129,7 @@ class BuildRpmTestCase(support.TempdirManager,
         os.remove(os.path.join(pkg_dir, 'dist', 'foo-0.1-1.noarch.rpm'))
 
 def test_suite():
-    return unittest.makeSuite(BuildRpmTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildRpmTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_bdist_wininst.py
+++ b/distutils/tests/test_bdist_wininst.py
@@ -34,7 +34,7 @@ class BuildWinInstTestCase(support.TempdirManager,
         self.assertGreater(len(exe_file), 10)
 
 def test_suite():
-    return unittest.makeSuite(BuildWinInstTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildWinInstTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_build.py
+++ b/distutils/tests/test_build.py
@@ -50,7 +50,7 @@ class BuildTestCase(support.TempdirManager,
         self.assertEqual(cmd.executable, os.path.normpath(sys.executable))
 
 def test_suite():
-    return unittest.makeSuite(BuildTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_build_clib.py
+++ b/distutils/tests/test_build_clib.py
@@ -130,7 +130,7 @@ class BuildCLibTestCase(support.TempdirManager,
         self.assertIn('libfoo.a', os.listdir(build_temp))
 
 def test_suite():
-    return unittest.makeSuite(BuildCLibTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildCLibTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -538,8 +538,8 @@ class ParallelBuildExtTestCase(BuildExtTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(BuildExtTestCase))
-    suite.addTest(unittest.makeSuite(ParallelBuildExtTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(BuildExtTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ParallelBuildExtTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/distutils/tests/test_build_py.py
+++ b/distutils/tests/test_build_py.py
@@ -173,7 +173,7 @@ class BuildPyTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(BuildPyTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildPyTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_build_scripts.py
+++ b/distutils/tests/test_build_scripts.py
@@ -106,7 +106,7 @@ class BuildScriptsTestCase(support.TempdirManager,
             self.assertIn(name, built)
 
 def test_suite():
-    return unittest.makeSuite(BuildScriptsTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(BuildScriptsTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -157,7 +157,7 @@ class CheckTestCase(support.LoggingSilencer,
                                  'restructuredtext': 1})
 
 def test_suite():
-    return unittest.makeSuite(CheckTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CheckTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_clean.py
+++ b/distutils/tests/test_clean.py
@@ -43,7 +43,7 @@ class cleanTestCase(support.TempdirManager,
         cmd.run()
 
 def test_suite():
-    return unittest.makeSuite(cleanTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(cleanTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_cmd.py
+++ b/distutils/tests/test_cmd.py
@@ -120,7 +120,7 @@ class CommandTestCase(unittest.TestCase):
             debug.DEBUG = False
 
 def test_suite():
-    return unittest.makeSuite(CommandTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CommandTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_config.py
+++ b/distutils/tests/test_config.py
@@ -135,7 +135,7 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(PyPIRCCommandTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(PyPIRCCommandTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_config_cmd.py
+++ b/distutils/tests/test_config_cmd.py
@@ -92,7 +92,7 @@ class ConfigTestCase(support.LoggingSilencer,
             self.assertFalse(os.path.exists(f))
 
 def test_suite():
-    return unittest.makeSuite(ConfigTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(ConfigTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_core.py
+++ b/distutils/tests/test_core.py
@@ -159,7 +159,7 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(stdout.readlines()[0], wanted)
 
 def test_suite():
-    return unittest.makeSuite(CoreTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CoreTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_cygwinccompiler.py
+++ b/distutils/tests/test_cygwinccompiler.py
@@ -90,7 +90,7 @@ class CygwinCCompilerTestCase(support.TempdirManager,
         self.assertRaises(ValueError, get_msvcr)
 
 def test_suite():
-    return unittest.makeSuite(CygwinCCompilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(CygwinCCompilerTestCase)
 
 if __name__ == '__main__':
     run_unittest(test_suite())

--- a/distutils/tests/test_dep_util.py
+++ b/distutils/tests/test_dep_util.py
@@ -74,7 +74,7 @@ class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(DepUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(DepUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -133,7 +133,7 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(DirUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(DirUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -525,8 +525,8 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(DistributionTestCase))
-    suite.addTest(unittest.makeSuite(MetadataTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(DistributionTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(MetadataTestCase))
     return suite
 
 if __name__ == "__main__":

--- a/distutils/tests/test_extension.py
+++ b/distutils/tests/test_extension.py
@@ -65,7 +65,7 @@ class ExtensionTestCase(unittest.TestCase):
                           "Unknown Extension options: 'chic'")
 
 def test_suite():
-    return unittest.makeSuite(ExtensionTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(ExtensionTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_file_util.py
+++ b/distutils/tests/test_file_util.py
@@ -118,7 +118,7 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(FileUtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(FileUtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_filelist.py
+++ b/distutils/tests/test_filelist.py
@@ -344,8 +344,8 @@ class FindAllTestCase(unittest.TestCase):
 
 def test_suite():
     return unittest.TestSuite([
-        unittest.makeSuite(FileListTestCase),
-        unittest.makeSuite(FindAllTestCase),
+        unittest.TestLoader().loadTestsFromTestCase(FileListTestCase),
+        unittest.TestLoader().loadTestsFromTestCase(FindAllTestCase),
     ])
 
 

--- a/distutils/tests/test_install.py
+++ b/distutils/tests/test_install.py
@@ -244,7 +244,7 @@ class InstallTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(InstallTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_install_data.py
+++ b/distutils/tests/test_install_data.py
@@ -69,7 +69,7 @@ class InstallDataTestCase(support.TempdirManager,
         self.assertTrue(os.path.exists(os.path.join(inst, rone)))
 
 def test_suite():
-    return unittest.makeSuite(InstallDataTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallDataTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_install_headers.py
+++ b/distutils/tests/test_install_headers.py
@@ -33,7 +33,7 @@ class InstallHeadersTestCase(support.TempdirManager,
         self.assertEqual(len(cmd.get_outputs()), 2)
 
 def test_suite():
-    return unittest.makeSuite(InstallHeadersTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallHeadersTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_install_lib.py
+++ b/distutils/tests/test_install_lib.py
@@ -109,7 +109,7 @@ class InstallLibTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(InstallLibTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallLibTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_install_scripts.py
+++ b/distutils/tests/test_install_scripts.py
@@ -76,7 +76,7 @@ class InstallScriptsTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(InstallScriptsTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(InstallScriptsTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_log.py
+++ b/distutils/tests/test_log.py
@@ -40,7 +40,7 @@ class TestLog(unittest.TestCase):
                         'Fαtal\t\\xc8rr\\u014dr')
 
 def test_suite():
-    return unittest.makeSuite(TestLog)
+    return unittest.TestLoader().loadTestsFromTestCase(TestLog)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_msvc9compiler.py
+++ b/distutils/tests/test_msvc9compiler.py
@@ -178,7 +178,7 @@ class msvc9compilerTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(msvc9compilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(msvc9compilerTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_msvccompiler.py
+++ b/distutils/tests/test_msvccompiler.py
@@ -132,7 +132,7 @@ class TestSpawn(unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(msvccompilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(msvccompilerTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_register.py
+++ b/distutils/tests/test_register.py
@@ -319,7 +319,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(RegisterTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(RegisterTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_sdist.py
+++ b/distutils/tests/test_sdist.py
@@ -483,7 +483,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             archive.close()
 
 def test_suite():
-    return unittest.makeSuite(SDistTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(SDistTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_spawn.py
+++ b/distutils/tests/test_spawn.py
@@ -133,7 +133,7 @@ class SpawnTestCase(support.TempdirManager,
 
 
 def test_suite():
-    return unittest.makeSuite(SpawnTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(SpawnTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -296,7 +296,7 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(SysconfigTestCase))
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(SysconfigTestCase))
     return suite
 
 

--- a/distutils/tests/test_text_file.py
+++ b/distutils/tests/test_text_file.py
@@ -101,7 +101,7 @@ class TextFileTestCase(support.TempdirManager, unittest.TestCase):
             in_file.close()
 
 def test_suite():
-    return unittest.makeSuite(TextFileTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(TextFileTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -246,7 +246,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(UnixCCompilerTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(UnixCCompilerTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_upload.py
+++ b/distutils/tests/test_upload.py
@@ -217,7 +217,7 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(uploadTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(uploadTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -303,7 +303,7 @@ class UtilTestCase(support.EnvironGuard, unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(UtilTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(UtilTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())

--- a/distutils/tests/test_version.py
+++ b/distutils/tests/test_version.py
@@ -89,7 +89,7 @@ class VersionTestCase(unittest.TestCase):
                           (v1, v2, res))
 
 def test_suite():
-    return unittest.makeSuite(VersionTestCase)
+    return unittest.TestLoader().loadTestsFromTestCase(VersionTestCase)
 
 if __name__ == "__main__":
     run_unittest(test_suite())


### PR DESCRIPTION
See https://github.com/python/cpython/pull/28299

loadTestsFromTestCase() is available since Python 2.7 at least.

Noticed while running the tests with current CPython main