### PR TITLE
tests: fix usage of requires_zlib() decorator

### DIFF
--- a/distutils/tests/py38compat.py
+++ b/distutils/tests/py38compat.py
@@ -2,6 +2,11 @@
 
 import contextlib
 import builtins
+import sys
+
+from test.support import requires_zlib
+import test.support
+
 
 ModuleNotFoundError = getattr(builtins, 'ModuleNotFoundError', ImportError)
 
@@ -51,3 +56,7 @@ try:
     from test.support.warnings_helper import save_restore_warnings_filters
 except (ModuleNotFoundError, ImportError):
     save_restore_warnings_filters = _save_restore_warnings_filters
+
+
+if sys.version_info < (3, 9):
+    requires_zlib = lambda: test.support.requires_zlib

--- a/distutils/tests/test_bdist_rpm.py
+++ b/distutils/tests/test_bdist_rpm.py
@@ -44,7 +44,7 @@ class BuildRpmTestCase(support.TempdirManager,
     # spurious sdtout/stderr output under Mac OS X
     @unittest.skipUnless(sys.platform.startswith('linux'),
                          'spurious sdtout/stderr output under Mac OS X')
-    @requires_zlib
+    @requires_zlib()
     @unittest.skipIf(find_executable('rpm') is None,
                      'the rpm command is not found')
     @unittest.skipIf(find_executable('rpmbuild') is None,
@@ -87,7 +87,7 @@ class BuildRpmTestCase(support.TempdirManager,
     # spurious sdtout/stderr output under Mac OS X
     @unittest.skipUnless(sys.platform.startswith('linux'),
                          'spurious sdtout/stderr output under Mac OS X')
-    @requires_zlib
+    @requires_zlib()
     # http://bugs.python.org/issue1533164
     @unittest.skipIf(find_executable('rpm') is None,
                      'the rpm command is not found')

--- a/distutils/tests/test_bdist_rpm.py
+++ b/distutils/tests/test_bdist_rpm.py
@@ -3,12 +3,15 @@
 import unittest
 import sys
 import os
-from test.support import run_unittest, requires_zlib
+from test.support import run_unittest
 
 from distutils.core import Distribution
 from distutils.command.bdist_rpm import bdist_rpm
 from distutils.tests import support
 from distutils.spawn import find_executable
+
+from .py38compat import requires_zlib
+
 
 SETUP_PY = """\
 from distutils.core import setup


### PR DESCRIPTION
It was passing the test function itself as an argument, skipping the test always.

See https://github.com/python/cpython/pull/28305 for the same fix in CPython.