### PR TITLE
tests: fix tests on Ubuntu 22.04

### DIFF
--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -288,11 +288,10 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         input = {}
         with open(config_h, encoding="utf-8") as f:
             result = sysconfig.parse_config_h(f, g=input)
-        self.assertTrue(input)
         self.assertTrue(input is result)
         with open(config_h, encoding="utf-8") as f:
             result = sysconfig.parse_config_h(f)
-        self.assertTrue(result)
+        self.assertTrue(isinstance(result, dict))
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
I added a test for sysconfig.parse_config_h() in 9d0b8cda407
which assumed pyconfig.h always has some macros defined and checked
that the result was non-empty.

On Ubuntu 22.04 the pyconfig.h is just a shim, including various platform specific
configs and not defining anything directly.

This changes the test to not assume anything about the output of parse_config_h() instead.