### PR TITLE
tests: use sys.executable instead of hardcoding "python"

### DIFF
--- a/distutils/tests/test_msvccompiler.py
+++ b/distutils/tests/test_msvccompiler.py
@@ -98,7 +98,7 @@ class TestSpawn(unittest.TestCase):
         compiler = _msvccompiler.MSVCCompiler()
         compiler._paths = "expected"
         inner_cmd = 'import os; assert os.environ["PATH"] == "expected"'
-        command = ['python', '-c', inner_cmd]
+        command = [sys.executable, '-c', inner_cmd]
 
         threads = [
             CheckThread(target=compiler.spawn, args=[command])


### PR DESCRIPTION
Don't assume a "python" is in PATH.

Fixes this test when run from an uninstalled Python at least.