### PR TITLE
[maint] removed unneded exception inclusion

### DIFF
--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -10,7 +10,7 @@ import sys
 import os
 import subprocess
 
-from distutils.errors import DistutilsPlatformError, DistutilsExecError
+from distutils.errors import DistutilsExecError
 from distutils.debug import DEBUG
 from distutils import log
 


### PR DESCRIPTION
After [previous commit](https://github.com/pypa/distutils/commit/221e8715518c23a45b5b81d884d05035e9c896dd), `DistutilsPlatformError` inclusion is not needed anymore since macos version's check has been moved to `util.py`.