### PR TITLE
Prevent warn on false positive for author/maintainer's email

### DIFF
--- a/distutils/command/check.py
+++ b/distutils/command/check.py
@@ -2,6 +2,8 @@
 
 Implements the Distutils 'check' command.
 """
+from email.utils import getaddresses
+
 from distutils.core import Command
 from distutils.errors import DistutilsSetupError
 
@@ -96,18 +98,38 @@ class check(Command):
 
         if missing:
             self.warn("missing required meta-data: %s"  % ', '.join(missing))
-        if metadata.author:
-            if not metadata.author_email:
-                self.warn("missing meta-data: if 'author' supplied, " +
-                          "'author_email' should be supplied too")
-        elif metadata.maintainer:
-            if not metadata.maintainer_email:
-                self.warn("missing meta-data: if 'maintainer' supplied, " +
-                          "'maintainer_email' should be supplied too")
-        else:
+        if not (
+            self._check_contact("author", metadata) or
+            self._check_contact("maintainer", metadata)
+        ):
             self.warn("missing meta-data: either (author and author_email) " +
                       "or (maintainer and maintainer_email) " +
                       "should be supplied")
+
+    def _check_contact(self, kind, metadata):
+        """
+        Returns True if the contact's name is specified and False otherwise.
+        This function will warn if the contact's email is not specified.
+        """
+        name = getattr(metadata, kind) or ''
+        email = getattr(metadata, kind + '_email') or ''
+
+        msg = ("missing meta-data: if '{}' supplied, " +
+               "'{}' should be supplied too")
+
+        if name and email:
+            return True
+
+        if name:
+            self.warn(msg.format(kind, kind + '_email'))
+            return True
+
+        addresses = [(alias, addr) for alias, addr in getaddresses([email])]
+        if any(alias and addr for alias, addr in addresses):
+            # The contact's name can be encoded in the email: `Name <email>`
+            return True
+
+        return False
 
     def check_restructuredtext(self):
         """Checks if the long string fields are reST-compliant."""

--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -71,6 +71,28 @@ class CheckTestCase(support.LoggingSilencer,
         cmd = self._run(metadata)
         self.assertEqual(cmd._warnings, 0)
 
+    def test_check_author_maintainer(self):
+        for kind in ("author", "maintainer"):
+            # ensure no warning when author_email or maintainer_email is given
+            # (the spec allows these fields to take the form "Name <email>")
+            metadata = {'url': 'xxx',
+                        kind + '_email': 'Name <name@email.com>',
+                        'name': 'xxx', 'version': 'xxx'}
+            cmd = self._run(metadata)
+            self.assertEqual(cmd._warnings, 0)
+
+            # the check should warn if only email is given and it does not
+            # contain the name
+            metadata[kind + '_email'] = 'name@email.com'
+            cmd = self._run(metadata)
+            self.assertEqual(cmd._warnings, 1)
+
+            # the check should warn if only the name is given
+            metadata[kind] = "Name"
+            del metadata[kind + '_email']
+            cmd = self._run(metadata)
+            self.assertEqual(cmd._warnings, 1)
+
     @unittest.skipUnless(HAS_DOCUTILS, "won't test without docutils")
     def test_check_document(self):
         pkg_info, dist = self.create_dist()


### PR DESCRIPTION
### Motivation

While I was working to support pyproject.toml metadata in setuptools, I received as a feedback from the community[^1] that indicates that setuptools warns the message bellow when `author_email` or `maintainer_email` are given in the form of `Person Name <email@address>` (and `author` or `email` are omitted):

> warning: check: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied

This can be seen as a false positive, because indeed both author's name and email are being provided.
This change aims to remove this false positive result from the checks.


### Notes
Please let me know if you don't think this change is suitable to this repository, and I can try to address the problem directly on the setuptools layer.

My idea on submitting it here is that it avoids the complexity of adding patches or overwriting commands in setuptools. If the users decide to use the stdlib's version of `distutils`, the only impact will be seeing the warning, but no feature will be compromised.

[^1]: https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/18