### PR TITLE
When building C++ extensions, replace all of linker command

### DIFF
--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -246,7 +246,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             self.cc.link(None, [], 'a.out', target_lang='c++')
             call_args = mock_spawn.call_args[0][0]
             assert len(call_args) >= 4
-            assert(call_args[:4] == ['g++-4.2', '-bundle', '-undefined', 'dynamic_lookup'])
+            assert(call_args[:4] == ['my_cxx', '-bundle', '-undefined', 'dynamic_lookup'])
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_explicit_ldshared(self):

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -245,8 +245,8 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             self.assertEqual(self.cc.linker_so[0:2], ['ccache','my_cc'])
             self.cc.link(None, [], 'a.out', target_lang='c++')
             call_args = mock_spawn.call_args[0][0]
-            if len(call_args) >= 2:
-                assert(call_args[:2] != ['my_cxx', 'my_cc'])
+            assert len(call_args) >= 4
+            assert(call_args[:4] == ['g++-4.2', '-bundle', '-undefined', 'dynamic_lookup'])
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_explicit_ldshared(self):

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -217,8 +217,9 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_cc_overrides_ldshared_for_cxx_correctly(self):
-        # Issue #18080:
+        # Issur https://github.com/pypa/distutils/issues/126
         # ensure that setting CC env variable also changes default linker
+        # correctly when C++ extensions are built
         def gcv(v):
             if v == 'LDSHARED':
                 return 'gcc-4.2 -bundle -undefined dynamic_lookup '

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -238,18 +238,18 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
         sysconfig.get_config_var = gcv
         sysconfig.get_config_vars = gcvs
         with patch.object(self.cc, 'spawn', return_value=None) as mock_spawn, \
-                patch.object(self.cc, '_need_link', return_value=True) as mock_need, \
-                patch.object(self.cc, 'mkpath', return_value=None) as mock_mkpath, \
+                patch.object(self.cc, '_need_link', return_value=True), \
+                patch.object(self.cc, 'mkpath', return_value=None), \
                 EnvironmentVarGuard() as env:
             env['CC'] = 'ccache my_cc'
             env['CXX'] = 'my_cxx'
             del env['LDSHARED']
             sysconfig.customize_compiler(self.cc)
-            self.assertEqual(self.cc.linker_so[0:2], ['ccache','my_cc'])
+            self.assertEqual(self.cc.linker_so[0:2], ['ccache', 'my_cc'])
             self.cc.link(None, [], 'a.out', target_lang='c++')
             call_args = mock_spawn.call_args[0][0]
-            assert len(call_args) >= 4
-            assert(call_args[:4] == ['my_cxx', '-bundle', '-undefined', 'dynamic_lookup'])
+            expected = ['my_cxx', '-bundle', '-undefined', 'dynamic_lookup']
+            assert call_args[:4] == expected
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_explicit_ldshared(self):

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -3,6 +3,7 @@ import os
 import sys
 import unittest
 from test.support import run_unittest
+from unittest.mock import patch
 
 from .py38compat import EnvironmentVarGuard
 
@@ -213,6 +214,38 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             del env['LDSHARED']
             sysconfig.customize_compiler(self.cc)
         self.assertEqual(self.cc.linker_so[0], 'my_cc')
+
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    def test_cc_overrides_ldshared_for_cxx_correctly(self):
+        # Issue #18080:
+        # ensure that setting CC env variable also changes default linker
+        def gcv(v):
+            if v == 'LDSHARED':
+                return 'gcc-4.2 -bundle -undefined dynamic_lookup '
+            elif v == 'CXX':
+                return 'g++-4.2'
+            return 'gcc-4.2'
+
+        def gcvs(*args, _orig=sysconfig.get_config_vars):
+            if args:
+                return list(map(sysconfig.get_config_var, args))
+            return _orig()
+
+        sysconfig.get_config_var = gcv
+        sysconfig.get_config_vars = gcvs
+        with patch.object(self.cc, 'spawn', return_value=None) as mock_spawn, \
+                patch.object(self.cc, '_need_link', return_value=True) as mock_need, \
+                patch.object(self.cc, 'mkpath', return_value=None) as mock_mkpath, \
+                EnvironmentVarGuard() as env:
+            env['CC'] = 'ccache my_cc'
+            env['CXX'] = 'my_cxx'
+            del env['LDSHARED']
+            sysconfig.customize_compiler(self.cc)
+            self.assertEqual(self.cc.linker_so[0:2], ['ccache','my_cc'])
+            self.cc.link(None, [], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            if len(call_args) >= 2:
+                assert(call_args[:2] != ['my_cxx', 'my_cc'])
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_explicit_ldshared(self):

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -217,9 +217,12 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_cc_overrides_ldshared_for_cxx_correctly(self):
-        # Issur https://github.com/pypa/distutils/issues/126
-        # ensure that setting CC env variable also changes default linker
-        # correctly when C++ extensions are built
+        """
+        Ensure that setting CC env variable also changes default linker
+        correctly when building C++ extensions.
+
+        pypa/distutils#126
+        """
         def gcv(v):
             if v == 'LDSHARED':
                 return 'gcc-4.2 -bundle -undefined dynamic_lookup '

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -233,15 +233,12 @@ class UnixCCompiler(CCompiler):
                 ld_args.extend(extra_postargs)
             self.mkpath(os.path.dirname(output_filename))
             try:
-                # If we are building an executable, use the C compiler
-                # given by linker_exe as the linker command,
-                # else use the C compiler + shared options given by
-                # linker_so.
-                linker = (
-                    self.linker_exe
-                    if target_desc == CCompiler.EXECUTABLE else
-                    self.linker_so
-                )[:]
+                # Select a linker based on context: linker_exe when
+                # building an executable or linker_so (with shared options)
+                # when building a shared library.
+                building_exe = target_desc == CCompiler.EXECUTABLE
+                linker = (self.linker_exe if building_exe else self.linker_so)[:]
+
                 if target_lang == "c++" and self.compiler_cxx:
                     env, linker_ne = _split_env(linker)
                     aix, linker_na = _split_aix(linker_ne)

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -196,7 +196,12 @@ class UnixCCompiler(CCompiler):
                     else:
                         offset = 0
 
-                    linker[i+offset] = self.compiler_cxx[i]
+                    if len(linker) >= len(self.linker_exe) and \
+                            linker[:len(self.linker_exe)] == self.linker_exe:
+                        linker = linker[:(i + offset)] + self.compiler_cxx + \
+                            linker[len(self.linker_exe):]
+                    else:
+                        linker[i+offset] = self.compiler_cxx[i]
 
                 if sys.platform == 'darwin':
                     linker = _osx_support.compiler_fixup(linker, ld_args)


### PR DESCRIPTION
instead of just one word of the linker command.
This is to support use case of CXX=g++ and CC=ccache gcc