### PR TITLE
Use cache_tag in default build_platlib dir

### DIFF
--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -81,7 +81,8 @@ class build(Command):
                             "--plat-name only supported on Windows (try "
                             "using './configure --help' on your platform)")
 
-        plat_specifier = ".%s-%d.%d" % (self.plat_name, *sys.version_info[:2])
+        plat_specifier = ".%s-%s" % (self.plat_name,
+                                     sys.implementation.cache_tag)
 
         # Make it so Python 2.x and Python 2.x with --with-pydebug don't
         # share the same build directories. Doing so confuses the build

--- a/distutils/tests/test_build.py
+++ b/distutils/tests/test_build.py
@@ -24,10 +24,10 @@ class BuildTestCase(support.TempdirManager,
         wanted = os.path.join(cmd.build_base, 'lib')
         self.assertEqual(cmd.build_purelib, wanted)
 
-        # build_platlib is 'build/lib.platform-x.x[-pydebug]'
+        # build_platlib is 'build/lib.platform-cache_tag[-pydebug]'
         # examples:
-        #   build/lib.macosx-10.3-i386-2.7
-        plat_spec = '.%s-%d.%d' % (cmd.plat_name, *sys.version_info[:2])
+        #   build/lib.macosx-10.3-i386-cpython39
+        plat_spec = '.%s-%s' % (cmd.plat_name, sys.implementation.cache_tag)
         if hasattr(sys, 'gettotalrefcount'):
             self.assertTrue(cmd.build_platlib.endswith('-pydebug'))
             plat_spec += '-pydebug'


### PR DESCRIPTION
Use `sys.implementation.cache_tag` instead of Python version to create
the default directory for `build_platlib`.  This guarantees that
the directories used by CPython and PyPy are distinct.  Prior to
the change, both CPython and PyPy would use e.g. `lib.linux-x86_64-3.9`.
With the change, they are going to use `lib.linux-x86_64-cpython39`
and `lib.linux-x86_64-pypy39` respectively.