### PR TITLE
Test that find_library_file works with Cygwin libraries

### DIFF
--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -101,9 +101,11 @@ class CygwinCCompiler(UnixCCompiler):
     compiler_type = 'cygwin'
     obj_extension = ".o"
     static_lib_extension = ".a"
-    shared_lib_extension = ".dll"
+    shared_lib_extension = ".dll.a"
+    dylib_lib_extension = ".dll"
     static_lib_format = "lib%s%s"
-    shared_lib_format = "%s%s"
+    shared_lib_format = "lib%s%s"
+    dylib_lib_format = "cyg%s%s"
     exe_extension = ".exe"
 
     def __init__(self, verbose=0, dry_run=0, force=0):

--- a/distutils/tests/test_cygwinccompiler.py
+++ b/distutils/tests/test_cygwinccompiler.py
@@ -31,6 +31,17 @@ class CygwinCCompilerTestCase(support.TempdirManager,
     def _get_config_h_filename(self):
         return self.python_h
 
+    @unittest.skipIf(sys.platform != "cygwin", "Not running on Cygwin")
+    @unittest.skipIf(not os.path.exists("/usr/lib/libbash.dll.a"), "Don't know a linkable library")
+    def test_find_library_file(self):
+        from distutils.cygwinccompiler import CygwinCCompiler
+        compiler = CygwinCCompiler()
+        link_name = "bash"
+        linkable_file = compiler.find_library_file(["/usr/lib"], link_name)
+        self.assertIsNotNone(linkable_file)
+        self.assertTrue(os.path.exists(linkable_file))
+        self.assertEquals(linkable_file, "/usr/lib/lib{:s}.dll.a".format(link_name))
+
     def test_check_config_h(self):
 
         # check_config_h looks for "GCC" in sys.version first


### PR DESCRIPTION
It worked for setuptools<60 and doesn't with setuptools>=60; I would like it to keep working.

Follow-up to python-pillow/pillow#6216

This is one of the patches mentioned in https://github.com/pypa/distutils/issues/73#issuecomment-991923804