### PR TITLE
Update Cygwin library name patterns

### DIFF
--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -101,9 +101,11 @@ class CygwinCCompiler(UnixCCompiler):
     compiler_type = 'cygwin'
     obj_extension = ".o"
     static_lib_extension = ".a"
-    shared_lib_extension = ".dll"
+    shared_lib_extension = ".dll.a"
+    dylib_lib_extension = ".dll"
     static_lib_format = "lib%s%s"
-    shared_lib_format = "%s%s"
+    shared_lib_format = "lib%s%s"
+    dylib_lib_format = "cyg%s%s"
     exe_extension = ".exe"
 
     def __init__(self, verbose=0, dry_run=0, force=0):


### PR DESCRIPTION
Shared and static libraries are under `/usr/lib/`; the dylibs are under `/usr/bin`; I think that's a sensible way to assign names to the three things (shared lib being import library, the thing needed at link time, with the dylib being needed at run time).

Replaces pypa/setuptools#3304; follow-up to python-pillow/pillow#6216.  Tests in #139.