### PR TITLE
Fix _is_gcc() for cross-compiling and treat clang/clang++ as gcc/g++

### DIFF
--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -260,7 +260,8 @@ class UnixCCompiler(CCompiler):
         return "-L" + dir
 
     def _is_gcc(self, compiler_name):
-        return "gcc" in compiler_name or "g++" in compiler_name
+        cnpat = re.compile('.*(gcc|g\+\+|clang|clang\+\+)$')
+        return not (cnpat.match(compiler_name) is None)
 
     def runtime_library_dir_option(self, dir):
         # XXX Hackish, at the very least.  See Python bug #445902:


### PR DESCRIPTION
This patch allows detecting gcc in the Yocto cross-compiler system better.
The compiler is not just called gcc or g++, the base name of the compiler may have a machine triplet prefix.
Treat clang and clang++ the same as gcc and g++ as they mimic the command line switches.