### PR TITLE
Fixed Issue on Windows+MSYS2 with unsafe handling of CC config variable.

### DIFF
--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -288,8 +288,10 @@ class UnixCCompiler(CCompiler):
         elif sys.platform[:7] == "freebsd":
             return "-Wl,-rpath=" + dir
         elif sys.platform[:5] == "hp-ux":
-            first_option = "-Wl,+s" if self._is_gcc() else "+s"
-            return [first_option, "-L" + dir]
+            return [
+                "-Wl,+s" if self._is_gcc() else "+s",
+                "-L" + dir,
+            ]
 
         # For all compilers, `-Wl` is the presumed way to
         # pass a compiler option to the linker and `-R` is

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -261,9 +261,6 @@ class UnixCCompiler(CCompiler):
 
     def _is_gcc(self):
         cc_var = sysconfig.get_config_var("CC")
-        if not cc_var:
-            return
-
         compiler = os.path.basename(shlex.split(cc_var)[0])
         return "gcc" in compiler or "g++" in compiler
 

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -276,7 +276,6 @@ class UnixCCompiler(CCompiler):
         # this time, there's no way to determine this information from
         # the configuration data stored in the Python installation, so
         # we use this hack.
-        compiler = os.path.basename(shlex.split(sysconfig.get_config_var("CC"))[0])
         if sys.platform[:6] == "darwin":
             from distutils.util import get_macosx_target_ver, split_version
             macosx_target_ver = get_macosx_target_ver()
@@ -287,8 +286,12 @@ class UnixCCompiler(CCompiler):
         elif sys.platform[:7] == "freebsd":
             return "-Wl,-rpath=" + dir
         elif sys.platform[:5] == "hp-ux":
-            if self._is_gcc(compiler):
-                return ["-Wl,+s", "-L" + dir]
+            cc_var = sysconfig.get_config_var("CC")
+            if cc_var is not None:
+                compiler = os.path.basename(shlex.split(cc_var)[0])
+                if self._is_gcc(compiler):
+                    return ["-Wl,+s", "-L" + dir]
+
             return ["+s", "-L" + dir]
 
         # For all compilers, `-Wl` is the presumed way to


### PR DESCRIPTION
On some platforms like Windows in combination with MSYS2 this part of code gets executed but the CC config variable does not exist.

I added a check for if the CC config variable was found and moved the code to the only platform case that requires it.