### PR TITLE
Fix finding headers when cross compiling

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -133,20 +133,27 @@ def get_python_inc(plat_specific=0, prefix=None):
 def _get_python_inc_posix(prefix, spec_prefix, plat_specific):
     if IS_PYPY and sys.version_info < (3, 8):
         return os.path.join(prefix, 'include')
-    if python_build:
-        # Assume the executable is in the build directory.  The
-        # pyconfig.h file should be in the same directory.  Since
-        # the build directory may not be the source directory, we
-        # must use "srcdir" from the makefile to find the "Include"
-        # directory.
-        if plat_specific:
-            return _sys_home or project_base
-        else:
-            incdir = os.path.join(get_config_var('srcdir'), 'Include')
-            return os.path.normpath(incdir)
-    return _get_python_inc_from_config(
-        plat_specific, spec_prefix
-    ) or _get_python_inc_posix_prefix(prefix)
+    return (
+        _get_python_inc_posix_python(plat_specific)
+        or _get_python_inc_from_config(plat_specific, spec_prefix)
+        or _get_python_inc_posix_prefix(prefix)
+    )
+
+
+def _get_python_inc_posix_python(plat_specific):
+    """
+    Assume the executable is in the build directory. The
+    pyconfig.h file should be in the same directory. Since
+    the build directory may not be the source directory,
+    use "srcdir" from the makefile to find the "Include"
+    directory.
+    """
+    if not python_build:
+        return
+    if plat_specific:
+        return _sys_home or project_base
+    incdir = os.path.join(get_config_var('srcdir'), 'Include')
+    return os.path.normpath(incdir)
 
 
 def _get_python_inc_from_config(plat_specific, spec_prefix):


### PR DESCRIPTION
This is a resubmission of #35, rebased and reworked a bit. I've included the same notes I posted in #35 describing the use case this patch enables:

We use the following techniques to make cross-compilation work:
* Apply this patch to either stdlib distutils (before setuptools 60) or the bundled distutils in setuptools.
* Add the directory containing the `_sysconfigdata` module for the host platform Python installation to `PYTHONPATH`, so that it can be imported from build platform Python.
* Set `_PYTHON_HOST_PLATFORM` to the correct value for the host platform (e.g. `linux-armv7l`)
* Set `_PYTHON_SYSCONFIGDATA_NAME` to the appropriate value for the host platform (e.g. `_sysconfigdata__linux_arm-linux-gnueabihf`).

`setup.py` is executed using build platform Python (by necessity, since the build machine can't normally run host platform binaries), but the `sysconfig` module returns data from the host platform Python installation, due to `_PYTHON_SYSCONFIGDATA_NAME`.

If the package contains extension modules, eventually `distutils.sysconfig.get_python_inc()` will be called to get the location of the Python headers. Without this patch, the build platform headers will be returned, since `get_python_inc()` returns paths relative to `sys.base_prefix` or `sys.base_exec_prefix`. This causes problems when the build platform word length doesn't match the host platform, resulting in errors like the following:
```
In file included from /nix/store/01kia41csjia67pry1rv828i9pvnnqfq-python3-3.9.12/include/python3.9/Python.h:50,
                 from btrfsutilpy.h:27,
                 from error.c:20:
/nix/store/01kia41csjia67pry1rv828i9pvnnqfq-python3-3.9.12/include/python3.9/pyport.h:741:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
  741 | #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
      |  ^~~~~
```

This patch avoids this problem by relying on sysconfig to provide the include paths. With `_PYTHON_SYSCONFIGDATA_NAME` set appropriately, the include directories will be returned from host platform Python.

The latest version of the patch will always use sysconfig on posix if the relevant config variables are defined, otherwise it will fall back to the current behavior.

I have been having trouble coming up with an effective and simple automated test due to the amount of infrastructure required. I think you would need multiple Python installations in order to demonstrate how `_PYTHON_SYSCONFIGDATA_NAME` can affect the return value of `get_python_inc()`. IMO, the most important thing is ensuring that existing (non-cross) use cases are not affected by this change.