### PR TITLE
Improve handling if runtime_library_dirs is set with cygwin/mingw

### DIFF
--- a/distutils/tests/test_cygwinccompiler.py
+++ b/distutils/tests/test_cygwinccompiler.py
@@ -48,6 +48,12 @@ class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
         self.assertTrue(os.path.exists(linkable_file))
         self.assertEquals(linkable_file, "/usr/lib/lib{:s}.dll.a".format(link_name))
 
+    @unittest.skipIf(sys.platform != "cygwin", "Not running on Cygwin")
+    def test_runtime_library_dir_option(self):
+        from distutils.cygwinccompiler import CygwinCCompiler
+        compiler = CygwinCCompiler()
+        self.assertEqual(compiler.runtime_library_dir_option('/foo'), [])
+
     def test_check_config_h(self):
 
         # check_config_h looks for "GCC" in sys.version first


### PR DESCRIPTION
On Windows there is nothing like rpath, so when CygwinCCompiler()
tries to link it will assume unix and pass rpath flags to the linker,
which will fail.

In cygwin this is currently patched away:
https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/python39.git;a=blob;f=3.1-enable-new-dtags.patch;h=716af3b14d3483e5a4
It is taking some macos fallback branch that is equal to library_dirs, which doesn't add much if
library_dirs is set, so in theory it should just return [] there.

This patch tries to bring it a bit closer to MSVCCompiler() which warns if
runtime_library_dirs is passed and raises if runtime_library_dir_option() is
called.

In the case of cygwin we only warn if runtime_library_dir_option() is called and return
nothing, so runtime_library_dirs is ignored. It's debatable if it should fail here,
but since cygwin is used to build unix software that might not be aware of this limitation
a warning seems more fitting.

In the mingw case we assume the user knows that they are targeting Windows and so we can be
more strict and error out like MSVCCompiler().

In both cases we warn if runtime_library_dirs is passed to the compiler, like with MSVC.