### PR TITLE
Remove warning about packages not containing `__init__.py` files

### DIFF
--- a/distutils/command/build_py.py
+++ b/distutils/command/build_py.py
@@ -201,16 +201,11 @@ class build_py(Command):
                     "but is not a directory" % package_dir
                 )
 
-        # Require __init__.py for all but the "root package"
+        # Directories without __init__.py are namespace packages (PEP 420).
         if package:
             init_py = os.path.join(package_dir, "__init__.py")
             if os.path.isfile(init_py):
                 return init_py
-            else:
-                log.warn(
-                    ("package init file '%s' not found " + "(or not a regular file)"),
-                    init_py,
-                )
 
         # Either not in a package at all (__init__.py not expected), or
         # __init__.py doesn't exist -- so don't return the filename.


### PR DESCRIPTION
Originally distutils implementation did not account for PEP 420 and included warns for package directories that did not contain ``__init__.py`` files.

After the acceptance of PEP 420, these warnings don't make more sense and sometimes can confuse users.
Recently this was pointed out in one of `setuptools` discussions: https://github.com/pypa/setuptools/discussions/3353#discussioncomment-2918006.

This PR removes the warning (and adds a test capturing the expectation).

Since the only change is a warning removal, this can be seen as a "progressive enhancement" over the versions of distutils existing in the standard library:
- Users that run setuptools using `SETUPTOOLS_USE_DISTUTILS=stdlib` will still see the warning, but the build will not fail or change in terms of outcome
- Users that run setuptools without the fallback will benefit from not seeing the outdated warning