### PR TITLE
Ensure Windows SDK directories are not cleared when caller specifies include/library dirs

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -260,9 +260,7 @@ class MSVCCompiler(CCompiler):
         ]
 
         self.__library_dirs = [
-            dir.rstrip(os.sep)
-            for dir in vc_env.get('lib', '').split(os.pathsep)
-            if dir
+            dir.rstrip(os.sep) for dir in vc_env.get('lib', '').split(os.pathsep) if dir
         ]
 
         self.preprocess_options = None
@@ -572,7 +570,9 @@ class MSVCCompiler(CCompiler):
 
     def _fix_lib_args(self, libraries, library_dirs, runtime_library_dirs):
         """Corrects arguments to the link_*() methods and add linker-specific dirs"""
-        fixed_args = super()._fix_lib_args(libraries, library_dirs, runtime_library_dirs)
+        fixed_args = super()._fix_lib_args(
+            libraries, library_dirs, runtime_library_dirs
+        )
         return (
             fixed_args[0],  # libraries
             fixed_args[1] + self.__library_dirs,

--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -261,7 +261,7 @@ class MSVCCompiler(CCompiler):
 
         self.__library_dirs = [
             dir.rstrip(os.sep)
-            for dir in vc_env.get('lib', '').split(os.pathsep):
+            for dir in vc_env.get('lib', '').split(os.pathsep)
             if dir
         ]
 

--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -563,7 +563,7 @@ class MSVCCompiler(CCompiler):
 
     def _fix_compile_args(self, output_dir, macros, include_dirs):
         """Corrects arguments to the compile() method and add compiler-specific dirs"""
-        fixed_args = super()._fix_lib_args(output_dir, macros, include_dirs)
+        fixed_args = super()._fix_compile_args(output_dir, macros, include_dirs)
         return (
             fixed_args[0],  # output_dir
             fixed_args[1],  # macros

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -91,6 +91,16 @@ class CCompiler:
     }
     language_order = ["c++", "objc", "c"]
 
+    include_dirs = []
+    """
+    include dirs specific to this compiler class
+    """
+
+    library_dirs = []
+    """
+    library dirs specific to this compiler class
+    """
+
     def __init__(self, verbose=0, dry_run=0, force=0):
         self.dry_run = dry_run
         self.force = force
@@ -383,6 +393,9 @@ class CCompiler:
         else:
             raise TypeError("'include_dirs' (if supplied) must be a list of strings")
 
+        # add include dirs for class
+        include_dirs += self.__class__.include_dirs
+
         return output_dir, macros, include_dirs
 
     def _prep_compile(self, sources, output_dir, depends=None):
@@ -438,6 +451,9 @@ class CCompiler:
             library_dirs = list(library_dirs) + (self.library_dirs or [])
         else:
             raise TypeError("'library_dirs' (if supplied) must be a list of strings")
+
+        # add library dirs for class
+        library_dirs += self.__class__.library_dirs
 
         if runtime_library_dirs is None:
             runtime_library_dirs = self.runtime_library_dirs

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -324,24 +324,7 @@ class CCompiler:
 
     def _setup_compile(self, outdir, macros, incdirs, sources, depends, extra):
         """Process arguments and decide which source files to compile."""
-        if outdir is None:
-            outdir = self.output_dir
-        elif not isinstance(outdir, str):
-            raise TypeError("'output_dir' must be a string or None")
-
-        if macros is None:
-            macros = self.macros
-        elif isinstance(macros, list):
-            macros = macros + (self.macros or [])
-        else:
-            raise TypeError("'macros' (if supplied) must be a list of tuples")
-
-        if incdirs is None:
-            incdirs = self.include_dirs
-        elif isinstance(incdirs, (list, tuple)):
-            incdirs = list(incdirs) + (self.include_dirs or [])
-        else:
-            raise TypeError("'include_dirs' (if supplied) must be a list of strings")
+        outdir, macros, incdirs = self._fix_compile_args(outdir, macros, incdirs)
 
         if extra is None:
             extra = []

--- a/distutils/tests/test_ccompiler.py
+++ b/distutils/tests/test_ccompiler.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import platform
+import textwrap
+import sysconfig
+
+import pytest
+
+from distutils import ccompiler
+
+
+def _make_strs(paths):
+    """
+    Convert paths to strings for legacy compatibility.
+    """
+    if sys.version_info > (3, 8) and platform.system() != "Windows":
+        return paths
+    return list(map(os.fspath, paths))
+
+
+@pytest.fixture
+def c_file(tmp_path):
+    c_file = tmp_path / 'foo.c'
+    gen_headers = ('Python.h',)
+    is_windows = platform.system() == "Windows"
+    plat_headers = ('windows.h',) * is_windows
+    all_headers = gen_headers + plat_headers
+    headers = '\n'.join(f'#include <{header}>\n' for header in all_headers)
+    payload = (
+        textwrap.dedent(
+            """
+        #headers
+        void PyInit_foo(void) {}
+        """
+        )
+        .lstrip()
+        .replace('#headers', headers)
+    )
+    c_file.write_text(payload)
+    return c_file
+
+
+def test_set_include_dirs(c_file):
+    """
+    Extensions should build even if set_include_dirs is invoked.
+    In particular, compiler-specific paths should not be overridden.
+    """
+    compiler = ccompiler.new_compiler()
+    python = sysconfig.get_paths()['include']
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))
+
+    # do it again, setting include dirs after any initialization
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))


### PR DESCRIPTION
This corrects a long-standing bug in the `_msvccompiler` implementation where the INCLUDE and LIB variables from the environment would be entirely overridden by `--include-dirs` and `--library-dirs` options (regardless of how they were passed). Instead, these should be appended after any user-specified directories. Overriding the `_fix_*_args` methods handles this for all users of the class.

This will make fixes such as [what PyWin32 uses](https://github.com/mhammond/pywin32/blob/e1c0237a6897dbc4adbfda6470711fade43228b7/setup.py#L530) redundant.