### PR TITLE
DOC: Extend Windows rpath error message with likely cause

### DIFF
--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -341,7 +341,9 @@ class Mingw32CCompiler(CygwinCCompiler):
 
     def runtime_library_dir_option(self, dir):
         raise DistutilsPlatformError(
-            "don't know how to set runtime library search path on Windows"
+            "don't know how to set runtime library search path on Windows\n"
+            "Most likely some Extension specifies 'runtime_library_dirs'\n"
+            "There isn't a way to implement that on Windows platforms"
         )
 
 

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -101,6 +101,12 @@ def get_msvcr():
             raise ValueError("Unknown MS Compiler version %s " % msc_ver)
 
 
+_runtime_library_dirs_msg = (
+    "Unable to set runtime library search path on Windows, "
+    "usually indicated by `runtime_library_dirs` parameter to Extension"
+    )
+
+
 class CygwinCCompiler(UnixCCompiler):
     """Handles the Cygwin port of the GNU C compiler to Windows."""
 
@@ -199,10 +205,7 @@ class CygwinCCompiler(UnixCCompiler):
         objects = copy.copy(objects or [])
 
         if runtime_library_dirs:
-            self.warn(
-                "I don't know what to do with 'runtime_library_dirs': "
-                + str(runtime_library_dirs)
-            )
+            self.warn(_runtime_library_dirs_msg)
 
         # Additional libraries
         libraries.extend(self.dll_libraries)
@@ -276,7 +279,7 @@ class CygwinCCompiler(UnixCCompiler):
         # cygwin doesn't support rpath. While in theory we could error
         # out like MSVC does, code might expect it to work like on Unix, so
         # just warn and hope for the best.
-        self.warn("don't know how to set runtime library search path on Windows")
+        self.warn(_runtime_library_dirs_msg)
         return []
 
     # -- Miscellaneous methods -----------------------------------------
@@ -340,11 +343,7 @@ class Mingw32CCompiler(CygwinCCompiler):
         self.dll_libraries = get_msvcr()
 
     def runtime_library_dir_option(self, dir):
-        raise DistutilsPlatformError(
-            "don't know how to set runtime library search path on Windows\n"
-            "Most likely some Extension specifies 'runtime_library_dirs'\n"
-            "There isn't a way to implement that on Windows platforms"
-        )
+        raise DistutilsPlatformError(_runtime_library_dirs_msg)
 
 
 # Because these compilers aren't configured in Python's pyconfig.h file by


### PR DESCRIPTION
Extend the error message for attempting to call `runtime_library_dir_option` on Windows with the most likely way I have found to trigger the call, creating an `Extension` that specifies `runtime_library_dirs`.

Hopefully this will give users something to search for in their `setup.py` and a starting point for what to change.  Inspired by pypa/setuptools#3450.

Since this is now an error, should this be documented in [the setuptools documentation for `Extension`](https://setuptools.pypa.io/en/latest/userguide/ext_modules.html#extension-api-reference) as well?