### PR TITLE
Fix finding library files

### DIFF
--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -373,8 +373,8 @@ class UnixCCompiler(CCompiler):
 
         searched = (
             os.path.join(root, lib_name)
-            for root in map(self._library_root, dirs)
             for lib_name in lib_names
+            for root in map(self._library_root, dirs)
         )
 
         found = filter(os.path.exists, searched)


### PR DESCRIPTION
Since setuptools 63.3.0, pillow couldn't be built anymore, see https://github.com/python-pillow/Pillow/issues/6471
This was broken after refactoring: https://github.com/pypa/setuptools/commit/25dcca2902780146a1ee298f18648334eb3cddff

I am now directly creating the PR here as discussed in https://github.com/pypa/setuptools/pull/3476