### PR TITLE
Make compiler.include_dirs expose all paths correct again for MSVC

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -224,14 +224,6 @@ class MSVCCompiler(CCompiler):
         self.plat_name = None
         self.initialized = False
 
-    @classmethod
-    def _configure(cls, vc_env):
-        """
-        Set class-level include/lib dirs.
-        """
-        cls.include_dirs = cls._parse_path(vc_env.get('include', ''))
-        cls.library_dirs = cls._parse_path(vc_env.get('lib', ''))
-
     @staticmethod
     def _parse_path(val):
         return [dir.rstrip(os.sep) for dir in val.split(os.pathsep) if dir]
@@ -250,12 +242,14 @@ class MSVCCompiler(CCompiler):
         # Get the vcvarsall.bat spec for the requested platform.
         plat_spec = PLAT_TO_VCVARS[plat_name]
 
+        # Add include/lib dirs from vcvarsall.bat
         vc_env = _get_vc_env(plat_spec)
         if not vc_env:
             raise DistutilsPlatformError(
                 "Unable to find a compatible " "Visual Studio installation."
             )
-        self._configure(vc_env)
+        self.include_dirs.extend(self._parse_path(vc_env.get('include', '')))
+        self.library_dirs.extend(self._parse_path(vc_env.get('lib', '')))
 
         self._paths = vc_env.get('path', '')
         paths = self._paths.split(os.pathsep)

--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -328,7 +328,8 @@ class MSVCCompiler(CCompiler):
             if strip_dir:
                 base = os.path.basename(base)
             else:
-                _, base = os.path.splitdrive(base)
+                if output_dir:
+                    _, base = os.path.splitdrive(base)
                 if base.startswith((os.path.sep, os.path.altsep)):
                     base = base[1:]
             try:

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -93,16 +93,6 @@ class CCompiler:
     }
     language_order = ["c++", "objc", "c"]
 
-    include_dirs = []
-    """
-    include dirs specific to this compiler class
-    """
-
-    library_dirs = []
-    """
-    library dirs specific to this compiler class
-    """
-
     def __init__(self, verbose=0, dry_run=0, force=0):
         self.dry_run = dry_run
         self.force = force
@@ -395,9 +385,6 @@ class CCompiler:
         else:
             raise TypeError("'include_dirs' (if supplied) must be a list of strings")
 
-        # add include dirs for class
-        include_dirs += self.__class__.include_dirs
-
         return output_dir, macros, include_dirs
 
     def _prep_compile(self, sources, output_dir, depends=None):
@@ -453,9 +440,6 @@ class CCompiler:
             library_dirs = list(library_dirs) + (self.library_dirs or [])
         else:
             raise TypeError("'library_dirs' (if supplied) must be a list of strings")
-
-        # add library dirs for class
-        library_dirs += self.__class__.library_dirs
 
         if runtime_library_dirs is None:
             runtime_library_dirs = self.runtime_library_dirs

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -314,18 +314,13 @@ class build_ext(Command):
             force=self.force,
         )
         customize_compiler(self.compiler)
-        # If we are cross-compiling, init the compiler now (if we are not
-        # cross-compiling, init would not hurt, but people may rely on
-        # late initialization of compiler even if they shouldn't...)
-        if os.name == 'nt' and self.plat_name != get_platform():
-            self.compiler.initialize(self.plat_name)
 
         # And make sure that any compile/link-related options (which might
         # come from the command-line or from the setup script) are set in
         # that CCompiler object -- that way, they automatically apply to
         # all compiling and linking done here.
         if self.include_dirs is not None:
-            self.compiler.set_include_dirs(self.include_dirs)
+            self.compiler.include_dirs[:0] = self.include_dirs
         if self.define is not None:
             # 'define' option is a list of (name,value) tuples
             for (name, value) in self.define:
@@ -336,11 +331,17 @@ class build_ext(Command):
         if self.libraries is not None:
             self.compiler.set_libraries(self.libraries)
         if self.library_dirs is not None:
-            self.compiler.set_library_dirs(self.library_dirs)
+            self.compiler.library_dirs[:0] = self.library_dirs
         if self.rpath is not None:
             self.compiler.set_runtime_library_dirs(self.rpath)
         if self.link_objects is not None:
             self.compiler.set_link_objects(self.link_objects)
+
+        # If we are cross-compiling, init the compiler now (if we are not
+        # cross-compiling, init would not hurt, but people may rely on
+        # late initialization of compiler even if they shouldn't...)
+        if os.name == 'nt' and self.plat_name != get_platform():
+            self.compiler.initialize(self.plat_name)
 
         # Now actually compile and link everything.
         self.build_extensions()

--- a/distutils/tests/test_ccompiler.py
+++ b/distutils/tests/test_ccompiler.py
@@ -1,12 +1,21 @@
 import os
+import io
 import sys
 import platform
 import textwrap
 import sysconfig
+import tempfile
+from test import support
 
 import pytest
 
 from distutils import ccompiler
+from distutils.core import Distribution
+from distutils.extension import Extension
+from distutils.command.build_ext import build_ext
+
+
+is_windows = platform.system() == "Windows"
 
 
 def _make_strs(paths):
@@ -22,8 +31,7 @@ def _make_strs(paths):
 def c_file(tmp_path):
     c_file = tmp_path / 'foo.c'
     gen_headers = ('Python.h',)
-    is_windows = platform.system() == "Windows"
-    plat_headers = ('windows.h',) * is_windows
+    plat_headers = ('stdlib.h',) + ('Windows.h',) * is_windows
     all_headers = gen_headers + plat_headers
     headers = '\n'.join(f'#include <{header}>\n' for header in all_headers)
     payload = (
@@ -40,16 +48,34 @@ def c_file(tmp_path):
     return c_file
 
 
-def test_set_include_dirs(c_file):
+def test_include_dirs(c_file):
     """
-    Extensions should build even if set_include_dirs is invoked.
-    In particular, compiler-specific paths should not be overridden.
+    Test basic standard include dirs to be available, including SDK on Windows.
     """
     compiler = ccompiler.new_compiler()
     python = sysconfig.get_paths()['include']
-    compiler.set_include_dirs([python])
+    compiler.add_include_dir(python)
     compiler.compile(_make_strs([c_file]))
 
-    # do it again, setting include dirs after any initialization
-    compiler.set_include_dirs([python])
-    compiler.compile(_make_strs([c_file]))
+
+@pytest.mark.skipif(not is_windows, reason="Test only on Windows")
+def test_ext_include_dirs(c_file):
+    """
+    Test that include_dirs in an extension does not replace standard include dirs.
+    """
+    ext = Extension('foo', _make_strs([c_file]), include_dirs=['_nonexisting_'])
+    dist = Distribution({'name': 'foo', 'ext_modules': [ext]})
+    cmd = build_ext(dist)
+    tmp_dir = tempfile.mkdtemp()
+    cmd.build_lib = tmp_dir
+    cmd.build_temp = tmp_dir
+
+    old_stdout = sys.stdout
+    if not support.verbose:
+        # silence compiler output
+        sys.stdout = io.StringIO()
+    try:
+        cmd.ensure_finalized()
+        cmd.run()
+    finally:
+        sys.stdout = old_stdout


### PR DESCRIPTION
Fixup etc. for changes in 9f9a3e5 / c84d3e5 which crashed the pywin32 CI builds recently - setuptools is currently frozen there <=63.2.0 until clarified. 
The problem happened at 
https://github.com/mhammond/pywin32/blob/fc69a1ecc150a13433a7a71d61bac52a5f3df42b/setup.py#L695
/ mhammond/pywin32@fc69a1e) ( @zooba )

Besides the unnecessary compatibility break the MSVC paths should probably not be hidden generally I think. 
(Otherwise pywin32 would need to dig into distutils internals `compiler.__class__.include_dirs` in a strange manner, a class variable which is only available after instance.initialize() ...)
