### PR TITLE
Fix, again, finding headers during cross compiling

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -165,9 +165,8 @@ def _get_python_inc_from_config(plat_specific, spec_prefix):
     platform Python installation, while the current Python
     executable is from the build platform installation.
     """
-    if not spec_prefix:
-        return
-    return get_config_var('CONF' * plat_specific + 'INCLUDEPY')
+    if spec_prefix is None:
+        return get_config_var('CONF' * plat_specific + 'INCLUDEPY')
 
 
 def _get_python_inc_posix_prefix(prefix):

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -164,6 +164,16 @@ def _get_python_inc_from_config(plat_specific, spec_prefix):
     the host
     platform Python installation, while the current Python
     executable is from the build platform installation.
+
+    >>> monkeypatch = getfixture('monkeypatch')
+    >>> gpifc = _get_python_inc_from_config
+    >>> monkeypatch.setitem(gpifc.__globals__, 'get_config_var', str.lower)
+    >>> gpifc(False, '/usr/bin/')
+    >>> gpifc(False, '')
+    >>> gpifc(False, None)
+    'includepy'
+    >>> gpifc(True, None)
+    'confincludepy'
     """
     if spec_prefix is None:
         return get_config_var('CONF' * plat_specific + 'INCLUDEPY')


### PR DESCRIPTION
Find the correct headers (from the host machine, not build) when cross compiling.
This should have been fixed in https://github.com/pypa/distutils/pull/145 but a follow up commit broke it again.

Note: I tested that normal and cross compilation of a package with native extensions succeed on a POSIX system.