### PR TITLE
Add DIST_EXTRA_CONFIG option for passing setup.cfg overrides during build

### DIFF
--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -357,7 +357,7 @@ Common commands: (see '--help-commands' for more)
 
         # Additional config indicated in the environment
         with contextlib.suppress(TypeError):
-            yield pathlib.Path(os.getenv("DISTUTILS_EXTRA_CONFIG"))
+            yield pathlib.Path(os.getenv("DIST_EXTRA_CONFIG"))
 
     def parse_config_files(self, filenames=None):  # noqa: C901
         from configparser import ConfigParser

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -359,6 +359,10 @@ Common commands: (see '--help-commands' for more)
         if os.path.isfile(local_file):
             files.append(local_file)
 
+        extra_file = os.getenv("DISTUTILS_EXTRA_CONFIG")
+        if extra_file and os.path.isfile(extra_file):
+            files.append(extra_file)
+
         if DEBUG:
             self.announce("using config files: %s" % ', '.join(files))
 

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -324,14 +324,14 @@ Common commands: (see '--help-commands' for more)
         should be parsed.  The filenames returned are guaranteed to exist
         (modulo nasty race conditions).
 
-        There are three possible config files: distutils.cfg in the
-        Distutils installation directory (ie. where the top-level
-        Distutils __inst__.py file lives), a file in the user's home
-        directory named .pydistutils.cfg on Unix and pydistutils.cfg
-        on Windows/Mac; and setup.cfg in the current directory.
-
-        The file in the user's home directory can be disabled with the
-        --no-user-cfg option.
+        There are multiple possible config files:
+        - distutils.cfg in the Distutils installation directory (i.e.
+          where the top-level Distutils __inst__.py file lives)
+        - a file in the user's home directory named .pydistutils.cfg
+          on Unix and pydistutils.cfg on Windows/Mac; may be disabled
+          with the ``--no-user-cfg`` option
+        - setup.cfg in the current directory
+        - a file named by an environment variable
         """
         check_environ()
         files = [str(path) for path in self._gen_paths() if path.is_file()]
@@ -355,6 +355,7 @@ Common commands: (see '--help-commands' for more)
         # All platforms support local setup.cfg
         yield pathlib.Path('setup.cfg')
 
+        # Additional config indicated in the environment
         with contextlib.suppress(TypeError):
             yield pathlib.Path(os.getenv("DISTUTILS_EXTRA_CONFIG"))
 

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -492,6 +492,27 @@ class TestMetadata(support.TempdirManager):
         finally:
             os.remove(user_filename)
 
+    def test_extra_pydistutils(self):
+        # make sure pydistutils.cfg is found
+        extra_filename = "overrides.cfg"
+
+        temp_dir = self.mkdtemp()
+        extra_filename = os.path.join(temp_dir, extra_filename)
+        with open(extra_filename, 'w') as f:
+            f.write('.')
+
+        # Testing will have been going terribly if this was set, but preserve
+        # it anyway (so it goes terribly but *consistently*)
+        old_extra_filename = os.environ.get("DISTUTILS_EXTRA_CONFIG")
+        os.environ["DISTUTILS_EXTRA_CONFIG"] = extra_filename
+        try:
+            dist = Distribution()
+            files = dist.find_config_files()
+            assert user_filename in files
+        finally:
+            os.remove(user_filename)
+            os.environ["DISTUTILS_EXTRA_CONFIG"] = old_extra_filename
+
     def test_fix_help_options(self):
         help_tuples = [('a', 'b', 'c', 'd'), (1, 2, 3, 4)]
         fancy_options = fix_help_options(help_tuples)

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -508,9 +508,9 @@ class TestMetadata(support.TempdirManager):
         try:
             dist = Distribution()
             files = dist.find_config_files()
-            assert user_filename in files
+            assert extra_filename in files
         finally:
-            os.remove(user_filename)
+            os.remove(extra_filename)
             os.environ["DISTUTILS_EXTRA_CONFIG"] = old_extra_filename
 
     def test_fix_help_options(self):

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -492,7 +492,7 @@ class TestMetadata(support.TempdirManager):
         finally:
             os.remove(user_filename)
 
-    def test_extra_pydistutils(self):
+    def test_extra_pydistutils(self, monkeypatch):
         # make sure pydistutils.cfg is found
         extra_filename = "overrides.cfg"
 
@@ -501,17 +501,13 @@ class TestMetadata(support.TempdirManager):
         with open(extra_filename, 'w') as f:
             f.write('.')
 
-        # Testing will have been going terribly if this was set, but preserve
-        # it anyway (so it goes terribly but *consistently*)
-        old_extra_filename = os.environ.get("DISTUTILS_EXTRA_CONFIG")
-        os.environ["DISTUTILS_EXTRA_CONFIG"] = extra_filename
+        monkeypatch.setenv('DISTUTILS_EXTRA_CONFIG', extra_filename)
         try:
             dist = Distribution()
             files = dist.find_config_files()
             assert extra_filename in files
         finally:
             os.remove(extra_filename)
-            os.environ["DISTUTILS_EXTRA_CONFIG"] = old_extra_filename
 
     def test_fix_help_options(self):
         help_tuples = [('a', 'b', 'c', 'd'), (1, 2, 3, 4)]

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -491,7 +491,7 @@ class TestMetadata(support.TempdirManager):
         jaraco.path.build({'overrides.cfg': '.'}, tmp_path)
         filename = tmp_path / 'overrides.cfg'
 
-        monkeypatch.setenv('DISTUTILS_EXTRA_CONFIG', filename)
+        monkeypatch.setenv('DIST_EXTRA_CONFIG', filename)
         dist = Distribution()
         files = dist.find_config_files()
         assert str(filename) in files

--- a/docs/distutils/configfile.rst
+++ b/docs/distutils/configfile.rst
@@ -36,7 +36,8 @@ consequences:
   :file:`setup.py`
 
 * installers can override anything in :file:`setup.cfg` using the command-line
-  options to :file:`setup.py`
+  options to :file:`setup.py` or by pointing :envvar:`DISTUTILS_EXTRA_CONFIG`
+  to another configuration file
 
 The basic syntax of the configuration file is simple:
 

--- a/docs/distutils/configfile.rst
+++ b/docs/distutils/configfile.rst
@@ -36,7 +36,7 @@ consequences:
   :file:`setup.py`
 
 * installers can override anything in :file:`setup.cfg` using the command-line
-  options to :file:`setup.py` or by pointing :envvar:`DISTUTILS_EXTRA_CONFIG`
+  options to :file:`setup.py` or by pointing :envvar:`DIST_EXTRA_CONFIG`
   to another configuration file
 
 The basic syntax of the configuration file is simple:


### PR DESCRIPTION
As discussed during https://github.com/pypa/cibuildwheel/pull/1144