### PR TITLE
Backfill `distutils.log.Log` for compatibility

### DIFF
--- a/distutils/log.py
+++ b/distutils/log.py
@@ -40,7 +40,7 @@ def set_verbosity(v):
 
 
 class Log(logging.Logger):
-    """distutils.log.Logger is deprecated, please use an alternative from `logging`."""
+    """distutils.log.Log is deprecated, please use an alternative from `logging`."""
 
     def __init__(self, threshold=WARN):
         warnings.warn(Log.__doc__)  # avoid DeprecationWarning to ensure warn is shown

--- a/distutils/log.py
+++ b/distutils/log.py
@@ -5,6 +5,7 @@ Retained for compatibility and should not be used.
 """
 
 import logging
+import warnings
 
 from ._log import log as _global_log
 
@@ -36,3 +37,21 @@ def set_verbosity(v):
         set_threshold(logging.INFO)
     elif v >= 2:
         set_threshold(logging.DEBUG)
+
+
+class Log(logging.Logger):
+    """distutils.log.Logger is deprecated, please use an alternative from `logging`."""
+
+    def __init__(self, threshold=WARN):
+        warnings.warn(Log.__doc__)  # avoid DeprecationWarning to ensure warn is shown
+        super().__init__(__name__, level=threshold)
+
+    @property
+    def threshold(self):
+        return self.level
+
+    @threshold.setter
+    def threshold(self, level):
+        self.setLevel(level)
+
+    warn = logging.Logger.warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,6 @@ filterwarnings=
 
 	# suppress warnings in deprecated compilers
 	ignore:(bcpp|msvc9?)compiler is deprecated
+
+	# suppress well know deprecation warning
+	ignore:distutils.log.Log is deprecated


### PR DESCRIPTION
in pypa/setuptools#3693 we learned that some projects rely on `distutils.log.Log` and users are asking for `distutils.log.Log` to be added back to ensure compatibility is not broken.

I am not sure what is the best way forward, but I am providing this PR if pypa/distutils' maintainers are interested in the "backfill" approach.

* I found just a few usages in https://grep.app/search?q=from%20distutils.log%20import%20Log,
  * However it seams that the main problem is users importing `numpy.disutils` without pinning setuptools.
* I am not sure about adding tests. I noticed that all the tests about deprecated `distutils.log` behaviour were removed.