### PR TITLE
Link directly to PEP

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -721,7 +721,7 @@ class build_ext(Command):
         name = ext.name.split('.')[-1]
         try:
             # Unicode module name support as defined in PEP-489
-            # https://www.python.org/dev/peps/pep-0489/#export-hook-name
+            # https://peps.python.org/pep-0489/#export-hook-name
             name.encode('ascii')
         except UnicodeEncodeError:
             suffix = 'U_' + name.encode('punycode').replace(b'-', b'_').decode('ascii')


### PR DESCRIPTION
Link directly to the PEP at its new home at https://peps.python.org/ rather than going via redirect at the old https://www.python.org/dev/peps/

(Split out from https://github.com/pypa/setuptools/pull/3770.)