### PR TITLE
Fixed accumulating include dirs after compile

### DIFF
--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -389,7 +389,7 @@ class CCompiler:
             raise TypeError("'macros' (if supplied) must be a list of tuples")
 
         if include_dirs is None:
-            include_dirs = self.include_dirs
+            include_dirs = list(self.include_dirs)
         elif isinstance(include_dirs, (list, tuple)):
             include_dirs = list(include_dirs) + (self.include_dirs or [])
         else:

--- a/distutils/tests/test_ccompiler.py
+++ b/distutils/tests/test_ccompiler.py
@@ -76,3 +76,17 @@ def test_has_function_prototype():
         assert not compiler.has_function(
             'setuptools_does_not_exist', includes=['<stdio.h>']
         )
+
+
+def test_include_dirs_after_multiple_compile_calls(c_file):
+    """
+    Calling compile multiple times should not change the include dirs
+    (regression test for setuptools issue #3591).
+    """
+    compiler = ccompiler.new_compiler()
+    python = sysconfig.get_paths()['include']
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))
+    assert compiler.include_dirs == [python]
+    compiler.compile(_make_strs([c_file]))
+    assert compiler.include_dirs == [python]


### PR DESCRIPTION
- makes a copy of include dir list to avoid increasing the list in subsequent calls of compile
- fix had been proposed by @mdavidsaver in [3591](https://github.com/pypa/setuptools/issues/3591)

The problem has been introduced by [this commit](https://github.com/pypa/distutils/commit/9f9a3e57643cb49796c1b08b5b5afb2826ecd7f), but it may also be problematic besides that: the internal include dir list is returned and can be modified unintentionally by the caller. 

Fixes https://github.com/pypa/setuptools/issues/3591 after merged back to `setuptools`.
