### PR TITLE
For 'get_python_inc', bypass missing config include dir

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -339,7 +339,6 @@ class MSVCCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         if not self.initialized:
             self.initialize()
         compile_info = self._setup_compile(
@@ -427,7 +426,6 @@ class MSVCCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         if not self.initialized:
             self.initialize()
         objects, output_dir = self._fix_object_args(objects, output_dir)
@@ -461,7 +459,6 @@ class MSVCCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         if not self.initialized:
             self.initialize()
         objects, output_dir = self._fix_object_args(objects, output_dir)

--- a/distutils/bcppcompiler.py
+++ b/distutils/bcppcompiler.py
@@ -64,7 +64,6 @@ class BCPPCompiler(CCompiler):
     exe_extension = '.exe'
 
     def __init__(self, verbose=0, dry_run=0, force=0):
-
         super().__init__(verbose, dry_run, force)
 
         # These executables are assumed to all be in the path.
@@ -98,7 +97,6 @@ class BCPPCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
             output_dir, macros, include_dirs, sources, depends, extra_postargs
         )
@@ -167,7 +165,6 @@ class BCPPCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         (objects, output_dir) = self._fix_object_args(objects, output_dir)
         output_filename = self.library_filename(output_libname, output_dir=output_dir)
 
@@ -200,7 +197,6 @@ class BCPPCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         # XXX this ignores 'build_temp'!  should follow the lead of
         # msvccompiler.py
 
@@ -219,7 +215,6 @@ class BCPPCompiler(CCompiler):
             output_filename = os.path.join(output_dir, output_filename)
 
         if self._need_link(objects, output_filename):
-
             # Figure out linker args based on type of target.
             if target_desc == CCompiler.EXECUTABLE:
                 startup_obj = 'c0w32'
@@ -381,7 +376,6 @@ class BCPPCompiler(CCompiler):
         extra_preargs=None,
         extra_postargs=None,
     ):
-
         (_, macros, include_dirs) = self._fix_compile_args(None, macros, include_dirs)
         pp_opts = gen_preprocess_options(macros, include_dirs)
         pp_args = ['cpp32.exe'] + pp_opts

--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -160,7 +160,7 @@ class Command:
             header = "command options for '%s':" % self.get_command_name()
         self.announce(indent + header, level=logging.INFO)
         indent = indent + "  "
-        for (option, _, _) in self.user_options:
+        for option, _, _ in self.user_options:
             option = option.translate(longopt_xlate)
             if option[-1] == "=":
                 option = option[:-1]
@@ -291,7 +291,7 @@ class Command:
         # Option_pairs: list of (src_option, dst_option) tuples
         src_cmd_obj = self.distribution.get_command_obj(src_cmd)
         src_cmd_obj.ensure_finalized()
-        for (src_option, dst_option) in option_pairs:
+        for src_option, dst_option in option_pairs:
             if getattr(self, dst_option) is None:
                 setattr(self, dst_option, getattr(src_cmd_obj, src_option))
 
@@ -325,7 +325,7 @@ class Command:
         run for the current distribution.  Return a list of command names.
         """
         commands = []
-        for (cmd_name, method) in self.sub_commands:
+        for cmd_name, method in self.sub_commands:
             if method is None or method(self):
                 commands.append(cmd_name)
         return commands

--- a/distutils/command/bdist.py
+++ b/distutils/command/bdist.py
@@ -33,7 +33,6 @@ class ListCompat(dict):
 
 
 class bdist(Command):
-
     description = "create a built (binary) distribution"
 
     user_options = [

--- a/distutils/command/bdist_dumb.py
+++ b/distutils/command/bdist_dumb.py
@@ -14,7 +14,6 @@ from distutils._log import log
 
 
 class bdist_dumb(Command):
-
     description = "create a \"dumb\" built distribution"
 
     user_options = [

--- a/distutils/command/bdist_rpm.py
+++ b/distutils/command/bdist_rpm.py
@@ -21,7 +21,6 @@ from distutils._log import log
 
 
 class bdist_rpm(Command):
-
     description = "create an RPM distribution"
 
     user_options = [
@@ -554,7 +553,7 @@ class bdist_rpm(Command):
             ('postun', 'post_uninstall', None),
         ]
 
-        for (rpm_opt, attr, default) in script_options:
+        for rpm_opt, attr, default in script_options:
             # Insert contents of file referred to, if no file is referred to
             # use 'default' as contents of script
             val = getattr(self, attr)

--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -16,7 +16,6 @@ def show_compilers():
 
 
 class build(Command):
-
     description = "build everything needed to install"
 
     user_options = [

--- a/distutils/command/build_clib.py
+++ b/distutils/command/build_clib.py
@@ -28,7 +28,6 @@ def show_compilers():
 
 
 class build_clib(Command):
-
     description = "build C/C++ libraries used by Python extensions"
 
     user_options = [
@@ -103,7 +102,7 @@ class build_clib(Command):
             self.compiler.set_include_dirs(self.include_dirs)
         if self.define is not None:
             # 'define' option is a list of (name,value) tuples
-            for (name, value) in self.define:
+            for name, value in self.define:
                 self.compiler.define_macro(name, value)
         if self.undef is not None:
             for macro in self.undef:
@@ -155,14 +154,14 @@ class build_clib(Command):
             return None
 
         lib_names = []
-        for (lib_name, build_info) in self.libraries:
+        for lib_name, build_info in self.libraries:
             lib_names.append(lib_name)
         return lib_names
 
     def get_source_files(self):
         self.check_library_list(self.libraries)
         filenames = []
-        for (lib_name, build_info) in self.libraries:
+        for lib_name, build_info in self.libraries:
             sources = build_info.get('sources')
             if sources is None or not isinstance(sources, (list, tuple)):
                 raise DistutilsSetupError(
@@ -175,7 +174,7 @@ class build_clib(Command):
         return filenames
 
     def build_libraries(self, libraries):
-        for (lib_name, build_info) in libraries:
+        for lib_name, build_info in libraries:
             sources = build_info.get('sources')
             if sources is None or not isinstance(sources, (list, tuple)):
                 raise DistutilsSetupError(

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -39,7 +39,6 @@ def show_compilers():
 
 
 class build_ext(Command):
-
     description = "build C/C++ extensions (compile/link to build directory)"
 
     # XXX thoughts on how to deal with complex command-line options like
@@ -328,7 +327,7 @@ class build_ext(Command):
             self.compiler.set_include_dirs(self.include_dirs)
         if self.define is not None:
             # 'define' option is a list of (name,value) tuples
-            for (name, value) in self.define:
+            for name, value in self.define:
                 self.compiler.define_macro(name, value)
         if self.undef is not None:
             for macro in self.undef:

--- a/distutils/command/build_py.py
+++ b/distutils/command/build_py.py
@@ -14,7 +14,6 @@ from distutils._log import log
 
 
 class build_py(Command):
-
     description = "\"build\" pure Python modules (copy to build directory)"
 
     user_options = [
@@ -310,7 +309,7 @@ class build_py(Command):
     def get_outputs(self, include_bytecode=1):
         modules = self.find_all_modules()
         outputs = []
-        for (package, module, module_file) in modules:
+        for package, module, module_file in modules:
             package = package.split('.')
             filename = self.get_module_outfile(self.build_lib, package, module)
             outputs.append(filename)
@@ -352,7 +351,7 @@ class build_py(Command):
 
     def build_modules(self):
         modules = self.find_modules()
-        for (package, module, module_file) in modules:
+        for package, module, module_file in modules:
             # Now "build" the module -- ie. copy the source file to
             # self.build_lib (the build directory for Python source).
             # (Actually, it gets copied to the directory for this package
@@ -375,7 +374,7 @@ class build_py(Command):
 
             # Now loop over the modules we found, "building" each one (just
             # copy it to self.build_lib).
-            for (package_, module, module_file) in modules:
+            for package_, module, module_file in modules:
                 assert package == package_
                 self.build_module(module, module_file, package)
 

--- a/distutils/command/build_scripts.py
+++ b/distutils/command/build_scripts.py
@@ -22,7 +22,6 @@ first_line_re = shebang_pattern
 
 
 class build_scripts(Command):
-
     description = "\"build\" scripts (copy and fixup #! line)"
 
     user_options = [

--- a/distutils/command/clean.py
+++ b/distutils/command/clean.py
@@ -11,7 +11,6 @@ from distutils._log import log
 
 
 class clean(Command):
-
     description = "clean up temporary files from 'build' command"
     user_options = [
         ('build-base=', 'b', "base build directory (default: 'build.build-base')"),

--- a/distutils/command/config.py
+++ b/distutils/command/config.py
@@ -21,7 +21,6 @@ LANG_EXT = {"c": ".c", "c++": ".cxx"}
 
 
 class config(Command):
-
     description = "prepare to build"
 
     user_options = [

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -180,7 +180,6 @@ def _pypy_hack(name):
 
 
 class install(Command):
-
     description = "install everything from build directory"
 
     user_options = [

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -11,7 +11,6 @@ from ..util import change_root, convert_path
 
 
 class install_data(Command):
-
     description = "install data files"
 
     user_options = [

--- a/distutils/command/install_headers.py
+++ b/distutils/command/install_headers.py
@@ -8,7 +8,6 @@ from ..core import Command
 
 # XXX force is never used
 class install_headers(Command):
-
     description = "install C/C++ header files"
 
     user_options = [

--- a/distutils/command/install_lib.py
+++ b/distutils/command/install_lib.py
@@ -16,7 +16,6 @@ PYTHON_SOURCE_EXTENSION = ".py"
 
 
 class install_lib(Command):
-
     description = "install all Python modules (extensions and pure Python)"
 
     # The byte-compilation options are a tad confusing.  Here are the

--- a/distutils/command/install_scripts.py
+++ b/distutils/command/install_scripts.py
@@ -12,7 +12,6 @@ from stat import ST_MODE
 
 
 class install_scripts(Command):
-
     description = "install scripts (Python or otherwise)"
 
     user_options = [

--- a/distutils/command/register.py
+++ b/distutils/command/register.py
@@ -17,7 +17,6 @@ from distutils._log import log
 
 
 class register(PyPIRCCommand):
-
     description = "register the distribution with the Python package index"
     user_options = PyPIRCCommand.user_options + [
         ('list-classifiers', None, 'list the valid Trove classifiers'),

--- a/distutils/command/sdist.py
+++ b/distutils/command/sdist.py
@@ -33,7 +33,6 @@ def show_formats():
 
 
 class sdist(Command):
-
     description = "create a source distribution (tarball, zip file, etc.)"
 
     def checking_metadata(self):

--- a/distutils/command/upload.py
+++ b/distutils/command/upload.py
@@ -27,7 +27,6 @@ _FILE_CONTENT_DIGESTS = {
 
 
 class upload(PyPIRCCommand):
-
     description = "upload binary package to PyPI"
 
     user_options = PyPIRCCommand.user_options + [

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -84,7 +84,6 @@ class CygwinCCompiler(UnixCCompiler):
     exe_extension = ".exe"
 
     def __init__(self, verbose=0, dry_run=0, force=0):
-
         super().__init__(verbose, dry_run, force)
 
         status, details = check_config_h()
@@ -269,7 +268,6 @@ class Mingw32CCompiler(CygwinCCompiler):
     compiler_type = 'mingw32'
 
     def __init__(self, verbose=0, dry_run=0, force=0):
-
         super().__init__(verbose, dry_run, force)
 
         shared_option = "-shared"

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -237,9 +237,9 @@ Common commands: (see '--help-commands' for more)
             options = attrs.get('options')
             if options is not None:
                 del attrs['options']
-                for (command, cmd_options) in options.items():
+                for command, cmd_options in options.items():
                     opt_dict = self.get_option_dict(command)
-                    for (opt, val) in cmd_options.items():
+                    for opt, val in cmd_options.items():
                         opt_dict[opt] = ("setup script", val)
 
             if 'licence' in attrs:
@@ -253,7 +253,7 @@ Common commands: (see '--help-commands' for more)
 
             # Now work on the rest of the attributes.  Any attribute that's
             # not already defined is invalid!
-            for (key, val) in attrs.items():
+            for key, val in attrs.items():
                 if hasattr(self.metadata, "set_" + key):
                     getattr(self.metadata, "set_" + key)(val)
                 elif hasattr(self.metadata, key):
@@ -414,7 +414,7 @@ Common commands: (see '--help-commands' for more)
         # to set Distribution options.
 
         if 'global' in self.command_options:
-            for (opt, (src, val)) in self.command_options['global'].items():
+            for opt, (src, val) in self.command_options['global'].items():
                 alias = self.negative_opt.get(opt)
                 try:
                     if alias:
@@ -585,7 +585,7 @@ Common commands: (see '--help-commands' for more)
             cmd_class.help_options, list
         ):
             help_option_found = 0
-            for (help_option, short, desc, func) in cmd_class.help_options:
+            for help_option, short, desc, func in cmd_class.help_options:
                 if hasattr(opts, parser.get_attr_name(help_option)):
                     help_option_found = 1
                     if callable(func):
@@ -603,7 +603,7 @@ Common commands: (see '--help-commands' for more)
         # Put the options from the command-line into their official
         # holding pen, the 'command_options' dictionary.
         opt_dict = self.get_option_dict(command)
-        for (name, value) in vars(opts).items():
+        for name, value in vars(opts).items():
             opt_dict[name] = ("command line", value)
 
         return args
@@ -696,7 +696,7 @@ Common commands: (see '--help-commands' for more)
         for option in self.display_options:
             is_display_option[option[0]] = 1
 
-        for (opt, val) in option_order:
+        for opt, val in option_order:
             if val and is_display_option.get(opt):
                 opt = translate_longopt(opt)
                 value = getattr(self.metadata, "get_" + opt)()
@@ -887,7 +887,7 @@ Common commands: (see '--help-commands' for more)
 
         if DEBUG:
             self.announce("  setting options for '%s' command:" % command_name)
-        for (option, (source, value)) in option_dict.items():
+        for option, (source, value) in option_dict.items():
             if DEBUG:
                 self.announce("    {} = {} (from {})".format(option, value, source))
             try:

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -113,7 +113,7 @@ class FancyGetopt:
 
     def _check_alias_dict(self, aliases, what):
         assert isinstance(aliases, dict)
-        for (alias, opt) in aliases.items():
+        for alias, opt in aliases.items():
             if alias not in self.option_index:
                 raise DistutilsGetoptError(
                     ("invalid %s '%s': " "option '%s' not defined")

--- a/distutils/file_util.py
+++ b/distutils/file_util.py
@@ -176,7 +176,6 @@ def copy_file(  # noqa: C901
 
 # XXX I suspect this is Unix-specific -- need porting help!
 def move_file(src, dst, verbose=1, dry_run=0):  # noqa: C901
-
     """Move a file 'src' to 'dst'.  If 'dst' is a directory, the file will
     be moved into it with the same name; otherwise, 'src' is just renamed
     to 'dst'.  Return the new full name of the file.

--- a/distutils/msvc9compiler.py
+++ b/distutils/msvc9compiler.py
@@ -499,7 +499,6 @@ class MSVCCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         if not self.initialized:
             self.initialize()
         compile_info = self._setup_compile(
@@ -586,7 +585,6 @@ class MSVCCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)
@@ -619,7 +617,6 @@ class MSVCCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)

--- a/distutils/msvccompiler.py
+++ b/distutils/msvccompiler.py
@@ -389,7 +389,6 @@ class MSVCCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         if not self.initialized:
             self.initialize()
         compile_info = self._setup_compile(
@@ -476,7 +475,6 @@ class MSVCCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)
@@ -509,7 +507,6 @@ class MSVCCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -130,12 +130,20 @@ def get_python_inc(plat_specific=0, prefix=None):
     return getter(resolved_prefix, prefix, plat_specific)
 
 
+@pass_none
+def _extant(path):
+    """
+    Replace path with None if it doesn't exist.
+    """
+    return path if os.path.exists(path) else None
+
+
 def _get_python_inc_posix(prefix, spec_prefix, plat_specific):
     if IS_PYPY and sys.version_info < (3, 8):
         return os.path.join(prefix, 'include')
     return (
         _get_python_inc_posix_python(plat_specific)
-        or _get_python_inc_from_config(plat_specific, spec_prefix)
+        or _extant(_get_python_inc_from_config(plat_specific, spec_prefix))
         or _get_python_inc_posix_prefix(prefix)
     )
 

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -482,7 +482,6 @@ def parse_makefile(fn, g=None):  # noqa: C901
                         del notdone[name]
 
                         if name.startswith('PY_') and name[3:] in renamed_variables:
-
                             name = name[3:]
                             if name not in done:
                                 done[name] = value

--- a/distutils/tests/test_bdist_dumb.py
+++ b/distutils/tests/test_bdist_dumb.py
@@ -29,7 +29,6 @@ class TestBuildDumb(
 ):
     @pytest.mark.usefixtures('needs_zlib')
     def test_simple_built(self):
-
         # let's create a simple package
         tmp_dir = self.mkdtemp()
         pkg_dir = os.path.join(tmp_dir, 'foo')

--- a/distutils/tests/test_build_clib.py
+++ b/distutils/tests/test_build_clib.py
@@ -71,7 +71,6 @@ class TestBuildCLib(support.TempdirManager):
         assert cmd.get_source_files() == ['a', 'b', 'c', 'd']
 
     def test_build_libraries(self):
-
         pkg_dir, dist = self.create_dist()
         cmd = build_clib(dist)
 

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -180,7 +180,6 @@ class TestBuildExt(TempdirManager):
         assert incl in cmd.include_dirs
 
     def test_optional_extension(self):
-
         # this extension will fail, but let's ignore this failure
         # with the optional argument.
         modules = [Extension('foo', ['xxx'], optional=False)]

--- a/distutils/tests/test_cmd.py
+++ b/distutils/tests/test_cmd.py
@@ -58,7 +58,6 @@ class TestCommand:
         cmd.make_file(infiles='in', outfile='out', func='func', args=())
 
     def test_dump_options(self, cmd):
-
         msgs = []
 
         def _announce(msg, level):

--- a/distutils/tests/test_cygwinccompiler.py
+++ b/distutils/tests/test_cygwinccompiler.py
@@ -47,7 +47,6 @@ class TestCygwinCCompiler(support.TempdirManager):
         assert compiler.runtime_library_dir_option('/foo') == []
 
     def test_check_config_h(self):
-
         # check_config_h looks for "GCC" in sys.version first
         # returns CONFIG_H_OK if found
         sys.version = (
@@ -72,7 +71,6 @@ class TestCygwinCCompiler(support.TempdirManager):
         assert check_config_h()[0] == CONFIG_H_OK
 
     def test_get_msvcr(self):
-
         # none
         sys.version = (
             '2.6.1 (r261:67515, Dec  6 2008, 16:42:21) '

--- a/distutils/tests/test_dep_util.py
+++ b/distutils/tests/test_dep_util.py
@@ -9,7 +9,6 @@ import pytest
 
 class TestDepUtil(support.TempdirManager):
     def test_newer(self):
-
         tmpdir = self.mkdtemp()
         new_file = os.path.join(tmpdir, 'new')
         old_file = os.path.abspath(__file__)

--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -51,7 +51,6 @@ class TestDirUtil(support.TempdirManager):
         assert stat.S_IMODE(os.stat(self.target2).st_mode) == 0o555 & ~umask
 
     def test_create_tree_verbosity(self, caplog):
-
         create_tree(self.root_target, ['one', 'two', 'three'], verbose=0)
         assert caplog.messages == []
         remove_tree(self.root_target, verbose=0)
@@ -63,7 +62,6 @@ class TestDirUtil(support.TempdirManager):
         remove_tree(self.root_target, verbose=0)
 
     def test_copy_tree_verbosity(self, caplog):
-
         mkpath(self.target, verbose=0)
 
         copy_tree(self.target, self.target2, verbose=0)

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -142,7 +142,7 @@ class TestDistributionBehavior(support.TempdirManager):
             result_dict.keys()
         )
 
-        for (key, value) in d.command_options.get('install').items():
+        for key, value in d.command_options.get('install').items():
             assert value == result_dict[key]
 
         # Test case: In a Virtual Environment

--- a/distutils/tests/test_register.py
+++ b/distutils/tests/test_register.py
@@ -158,7 +158,6 @@ class TestRegister(BasePyPIRCCommandTestCase):
         assert b'xxx' in self.conn.reqs[1].data
 
     def test_password_not_in_file(self):
-
         self.write_file(self.rc, PYPIRC_NOPASSWORD)
         cmd = self._get_cmd()
         cmd._set_config()

--- a/distutils/tests/test_sdist.py
+++ b/distutils/tests/test_sdist.py
@@ -162,7 +162,6 @@ class TestSDist(BasePyPIRCCommandTestCase):
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_add_defaults(self):
-
         # http://bugs.python.org/issue2279
 
         # add_default should also include

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -297,3 +297,22 @@ class TestSysconfig:
             cmd, env={**os.environ, "PYTHONPATH": distutils_path}
         )
         assert out == "True"
+
+    def test_get_python_inc_missing_config_dir(self, monkeypatch):
+        """
+        In portable Python installations, the sysconfig will be broken,
+        pointing to the directories where the installation was built and
+        not where it currently is. In this case, ensure that the missing
+        directory isn't used for get_python_inc.
+
+        See pypa/distutils#178.
+        """
+
+        def override(name):
+            if name == 'INCLUDEPY':
+                return '/does-not-exist'
+            return sysconfig.get_config_var(name)
+
+        monkeypatch.setattr(sysconfig, 'get_config_var', override)
+
+        assert os.path.exists(sysconfig.get_python_inc())

--- a/distutils/tests/test_upload.py
+++ b/distutils/tests/test_upload.py
@@ -77,7 +77,6 @@ class TestUpload(BasePyPIRCCommandTestCase):
         return self.last_open
 
     def test_finalize_options(self):
-
         # new format
         self.write_file(self.rc, PYPIRC)
         dist = Distribution()

--- a/distutils/text_file.py
+++ b/distutils/text_file.py
@@ -180,7 +180,6 @@ class TextFile:
                 line = None
 
             if self.strip_comments and line:
-
                 # Look for the first "#" in the line.  If none, never
                 # mind.  If we find one and it's the first character, or
                 # is not preceded by "\", then it starts a comment --

--- a/distutils/unixccompiler.py
+++ b/distutils/unixccompiler.py
@@ -103,7 +103,6 @@ def _linker_params(linker_cmd, compiler_cmd):
 
 
 class UnixCCompiler(CCompiler):
-
     compiler_type = 'unix'
 
     # These are used by CCompiler in two places: the constructor sets

--- a/distutils/version.py
+++ b/distutils/version.py
@@ -169,7 +169,6 @@ class StrictVersion(Version):
             self.prerelease = None
 
     def __str__(self):
-
         if self.version[2] == 0:
             vstring = '.'.join(map(str, self.version[0:2]))
         else:


### PR DESCRIPTION
- Add xfail test capturing missed expectation. Ref pypa/distutils#178.
- In _get_python_inc_posix, only return an extant path from the sysconfig. Fixes pypa/distutils#178.
