### PR TITLE
distutils.ccompiler: Remove correct executable file on Windows

### DIFF
--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -903,7 +903,9 @@ int main (int argc, char **argv) {
         except (LinkError, TypeError):
             return False
         else:
-            os.remove(os.path.join(self.output_dir or '', "a.out"))
+            os.remove(
+                self.executable_filename("a.out", output_dir=self.output_dir or '')
+            )
         finally:
             for fn in objects:
                 os.remove(fn)

--- a/distutils/tests/test_ccompiler.py
+++ b/distutils/tests/test_ccompiler.py
@@ -55,7 +55,6 @@ def test_set_include_dirs(c_file):
     compiler.compile(_make_strs([c_file]))
 
 
-@pytest.mark.xfail('platform.system() == "Windows"')
 def test_has_function_prototype():
     # Issue https://github.com/pypa/setuptools/issues/3648
     # Test prototype-generating behavior.


### PR DESCRIPTION
The previous code did not take into account the .exe file extension on Windows.