### PR TITLE
distutils.ccompiler.CCompiler.has_function: Quote #include argument

### DIFF
--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -860,7 +860,7 @@ class CCompiler:
         f = os.fdopen(fd, "w")
         try:
             for incl in includes:
-                f.write("""#include %s\n""" % incl)
+                f.write("""#include "%s"\n""" % incl)
             if not includes:
                 # Use "char func(void);" as the prototype to follow
                 # what autoconf does.  This prototype does not match

--- a/distutils/tests/test_ccompiler.py
+++ b/distutils/tests/test_ccompiler.py
@@ -66,15 +66,15 @@ def test_has_function_prototype():
     assert compiler.has_function('exit')
     with pytest.deprecated_call(match='includes is deprecated'):
         # abort() is a valid expression with the <stdlib.h> prototype.
-        assert compiler.has_function('abort', includes=['<stdlib.h>'])
+        assert compiler.has_function('abort', includes=['stdlib.h'])
     with pytest.deprecated_call(match='includes is deprecated'):
         # But exit() is not valid with the actual prototype in scope.
-        assert not compiler.has_function('exit', includes=['<stdlib.h>'])
+        assert not compiler.has_function('exit', includes=['stdlib.h'])
     # And setuptools_does_not_exist is not declared or defined at all.
     assert not compiler.has_function('setuptools_does_not_exist')
     with pytest.deprecated_call(match='includes is deprecated'):
         assert not compiler.has_function(
-            'setuptools_does_not_exist', includes=['<stdio.h>']
+            'setuptools_does_not_exist', includes=['stdio.h']
         )
 
 


### PR DESCRIPTION
Arguably, this is a historic wart in the interface, which is why I subconsciously fixed it in commit 56a5b333b2a8 ("distutils.ccompiler: Make has_function work with more C99 compilers").  But it's clearly not a backwards-compatible change, so it's wrong and has to be reverted.

Fixes pypa/setuptools#3820.