### PR TITLE
"Fix" interoperability of `rfc822_escape` with stblib's `email` package

### DIFF
--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -1,4 +1,8 @@
 """Tests for distutils.util."""
+import email
+import email.policy
+import email.generator
+import io
 import os
 import sys
 import sysconfig as stdlib_sysconfig
@@ -184,12 +188,55 @@ class TestUtil:
         for n in no:
             assert not strtobool(n)
 
-    def test_rfc822_escape(self):
-        header = 'I am a\npoor\nlonesome\nheader\n'
-        res = rfc822_escape(header)
-        wanted = ('I am a%(8s)spoor%(8s)slonesome%(8s)s' 'header%(8s)s') % {
-            '8s': '\n' + 8 * ' '
-        }
+    indent = 8 * ' '
+
+    @pytest.mark.parametrize(
+        "given,wanted",
+        [
+            # 0x0b, 0x0c, ..., etc are also considered a line break by Python
+            ("hello\x0b\nworld\n", f"hello\x0b{indent}\n{indent}world\n{indent}"),
+            ("hello\x1eworld", f"hello\x1e{indent}world"),
+            ("", ""),
+            (
+                "I am a\npoor\nlonesome\nheader\n",
+                f"I am a\n{indent}poor\n{indent}lonesome\n{indent}header\n{indent}",
+            ),
+        ],
+    )
+    def test_rfc822_escape(self, given, wanted):
+        """
+        We want to ensure a multi-line header parses correctly.
+
+        For interoperability, the escaped value should also "round-trip" over
+        `email.generator.Generator.flatten` and `email.message_from_*`
+        (see pypa/setuptools#4033).
+
+        The main issue is that internally `email.policy.EmailPolicy` uses
+        `splitlines` which will split on some control chars. If all the new lines
+        are not prefixed with spaces, the parser will interrupt reading
+        the current header and produce an incomplete value, while
+        incorrectly interpreting the rest of the headers as part of the payload.
+        """
+        res = rfc822_escape(given)
+
+        policy = email.policy.EmailPolicy(
+            utf8=True,
+            mangle_from_=False,
+            max_line_length=0,
+        )
+        with io.StringIO() as buffer:
+            raw = f"header: {res}\nother-header: 42\n\npayload\n"
+            orig = email.message_from_string(raw)
+            email.generator.Generator(buffer, policy=policy).flatten(orig)
+            buffer.seek(0)
+            regen = email.message_from_file(buffer)
+
+        for msg in (orig, regen):
+            assert msg.get_payload() == "payload\n"
+            assert msg["other-header"] == "42"
+            # Generator may replace control chars with `\n`
+            assert set(msg["header"].splitlines()) == set(res.splitlines())
+
         assert res == wanted
 
     def test_dont_write_bytecode(self):

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -508,6 +508,12 @@ def rfc822_escape(header):
     """Return a version of the string escaped for inclusion in an
     RFC-822 header, by ensuring there are 8 spaces space after each newline.
     """
-    lines = header.split('\n')
-    sep = '\n' + 8 * ' '
-    return sep.join(lines)
+    indent = 8 * " "
+    lines = header.splitlines(keepends=True)
+
+    # Emulate the behaviour of `str.split`
+    # (the terminal line break in `splitlines` does not result in an extra line):
+    ends_in_newline = lines and lines[-1].splitlines()[0] != lines[-1]
+    suffix = indent if ends_in_newline else ""
+
+    return indent.join(lines) + suffix


### PR DESCRIPTION
In pypa/setuptools#4033 we learned that there are some "interoperability challenges" regarding the way distutil's implementation of RFC822 escaping works and the way stdlib's `email` package works (which is in turn used by `pypa/wheel` and probably other `pypa` projects).

While there is no bug in the existing implementation of `pypa/distutils` *per se*[^1], when someone attempts to re-generate the `METADATA` file using the stdlib (as in `pypa/wheel`), the resulting file can make the parser choke on control characters that are interpreted by Python as line breaks.

I am proposing this PR in `pypa/distutils` because I think it would be nice to make the `rfc822_escape` function more robust.
However, if the maintainers of `pypa/distutils` believe that this is not the best place for tackling the issue (since the produced files are not technically broken), there are 2 alternatives: (a) re-implement `rfc822_escape` in `setuptools` and patch if necessary, (b) discuss with `pypa/wheel` if the problem can be handled there[^2]. Please let me know your suggestion.

### Implemented changes
- [Modified `test_utils.test_rfc822_escape`, capturing interoperability requirements](https://github.com/pypa/distutils/commit/222b249f4f7ee9c1b2fae7f483db88c031fe4302)
- [Added `test_dist.TestMetadata.test_round_trip_through_email_generator`, capturing interoperability requirements](https://github.com/pypa/distutils/commit/157fbfed51a405866c9f63cc75c69cfac6b8735e)
- ["Fix"/improve interoperability of `distutils.util.rfc822_escape` with stblib's `email` library](https://github.com/pypa/distutils/commit/0ece9871247625ed3541b66529ca654039a5d8b5)

[^1]: The generated `PKG-INFO` files parse just fine...
[^2]: The file that actually fails to parse correctly is produced in [`bdist_wheel`](https://github.com/pypa/wheel/blob/0.41.2/src/wheel/bdist_wheel.py#L587)