### PR TITLE
CI: disable fail-fast for all jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python:
         - "3.8"
@@ -82,6 +83,7 @@ jobs:
     # disabled due to lack of Rust support pypa/setuptools#3921
     if: ${{ false }}
     strategy:
+      fail-fast: false
       matrix:
         python:
         - 39
@@ -110,6 +112,7 @@ jobs:
     # Integration testing with setuptools
     if: ${{ false }}  # disabled for deprecation warnings
     strategy:
+      fail-fast: false
       matrix:
         python:
         - "3.10"


### PR DESCRIPTION
In case one job fails permanently we still would like to know if the other jobs pass.