### PR TITLE
Limit mutating global state

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -152,3 +152,10 @@ def temp_home(tmp_path, monkeypatch):
 def fake_home(fs, monkeypatch):
     home = fs.create_dir('/fakehome')
     return _set_home(monkeypatch, pathlib.Path(home.path))
+
+
+@pytest.fixture
+def disable_macos_customization(monkeypatch):
+    from distutils import sysconfig
+
+    monkeypatch.setattr(sysconfig, '_customize_macos', lambda: None)

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -266,6 +266,27 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
         )
 
 
+def _customize_macos():
+    if sys.platform != "darwin":
+        return
+
+    # Perform first-time customization of compiler-related
+    # config vars on OS X now that we know we need a compiler.
+    # This is primarily to support Pythons from binary
+    # installers.  The kind and paths to build tools on
+    # the user system may vary significantly from the system
+    # that Python itself was built on.  Also the user OS
+    # version and build tools may not support the same set
+    # of CPU architectures for universal builds.
+    global _config_vars
+    # Use get_config_var() to ensure _config_vars is initialized.
+    if not get_config_var('CUSTOMIZED_OSX_COMPILER'):
+        import _osx_support
+
+        _osx_support.customize_compiler(_config_vars)
+        _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
+
+
 def customize_compiler(compiler):  # noqa: C901
     """Do any platform-specific customization of a CCompiler instance.
 
@@ -273,22 +294,7 @@ def customize_compiler(compiler):  # noqa: C901
     varies across Unices and is stored in Python's Makefile.
     """
     if compiler.compiler_type == "unix":
-        if sys.platform == "darwin":
-            # Perform first-time customization of compiler-related
-            # config vars on OS X now that we know we need a compiler.
-            # This is primarily to support Pythons from binary
-            # installers.  The kind and paths to build tools on
-            # the user system may vary significantly from the system
-            # that Python itself was built on.  Also the user OS
-            # version and build tools may not support the same set
-            # of CPU architectures for universal builds.
-            global _config_vars
-            # Use get_config_var() to ensure _config_vars is initialized.
-            if not get_config_var('CUSTOMIZED_OSX_COMPILER'):
-                import _osx_support
-
-                _osx_support.customize_compiler(_config_vars)
-                _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
+        _customize_macos()
 
         (
             cc,

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -267,17 +267,20 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
 
 
 def _customize_macos():
+    """
+    Perform first-time customization of compiler-related
+    config vars on macOS. Use after a compiler is known
+    to be needed. This customization exists primarily to support Pythons
+    from binary installers. The kind and paths to build tools on
+    the user system may vary significantly from the system
+    that Python itself was built on.  Also the user OS
+    version and build tools may not support the same set
+    of CPU architectures for universal builds.
+    """
+
     if sys.platform != "darwin":
         return
 
-    # Perform first-time customization of compiler-related
-    # config vars on OS X now that we know we need a compiler.
-    # This is primarily to support Pythons from binary
-    # installers.  The kind and paths to build tools on
-    # the user system may vary significantly from the system
-    # that Python itself was built on.  Also the user OS
-    # version and build tools may not support the same set
-    # of CPU architectures for universal builds.
     global _config_vars
     # Use get_config_var() to ensure _config_vars is initialized.
     if not get_config_var('CUSTOMIZED_OSX_COMPILER'):

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -10,6 +10,7 @@ Email:        <fdrake@acm.org>
 """
 
 import os
+import functools
 import re
 import sys
 import sysconfig
@@ -266,6 +267,7 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
         )
 
 
+@functools.lru_cache()
 def _customize_macos():
     """
     Perform first-time customization of compiler-related
@@ -278,16 +280,9 @@ def _customize_macos():
     of CPU architectures for universal builds.
     """
 
-    if sys.platform != "darwin":
-        return
-
-    global _config_vars
-    # Use get_config_var() to ensure _config_vars is initialized.
-    if not get_config_var('CUSTOMIZED_OSX_COMPILER'):
-        import _osx_support
-
-        _osx_support.customize_compiler(_config_vars)
-        _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
+    sys.platform == "darwin" and __import__('_osx_support').customize_compiler(
+        get_config_vars()
+    )
 
 
 def customize_compiler(compiler):  # noqa: C901

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -98,8 +98,6 @@ class TestSysconfig:
             'CCSHARED': '--sc-ccshared',
             'LDSHARED': 'sc_ldshared',
             'SHLIB_SUFFIX': 'sc_shutil_suffix',
-            # On macOS, disable _osx_support.customize_compiler()
-            'CUSTOMIZED_OSX_COMPILER': 'True',
         }
 
         comp = compiler()
@@ -111,6 +109,7 @@ class TestSysconfig:
         return comp
 
     @pytest.mark.skipif("get_default_compiler() != 'unix'")
+    @pytest.mark.usefixtures('disable_macos_customization')
     def test_customize_compiler(self):
         # Make sure that sysconfig._config_vars is initialized
         sysconfig.get_config_vars()

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -248,6 +248,7 @@ class TestUnixCCompiler(support.TempdirManager):
         assert self.cc.linker_so[0] == 'my_cc'
 
     @pytest.mark.skipif('platform.system == "Windows"')
+    @pytest.mark.usefixtures('disable_macos_customization')
     def test_cc_overrides_ldshared_for_cxx_correctly(self):
         """
         Ensure that setting CC env variable also changes default linker

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,8 @@
 [lint]
+select = [
+	"C901",
+	"W",
+]
 ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,6 @@ testing =
 docs =
 	# upstream
 	sphinx >= 3.5
-	# workaround for sphinx/sphinx-doc#11662
-	sphinx < 7.2.5
 	jaraco.packaging >= 9.3
 	rst.linker >= 1.9
 	furo

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ extras =
 [testenv:diffcov]
 description = run tests and check that diff from main is covered
 deps =
+	{[testenv]deps}
 	diff-cover
 commands =
 	pytest {posargs} --cov-report xml


### PR DESCRIPTION
- **Remove Sphinx pin. Ref sphinx-doc/sphinx#11662.**
- **Include deps from the base config in diffcov.**
- **Enable complexity check and pycodestyle warnings. Closes jaraco/skeleton#110.**
- **Extract a method for customizing the compiler for macOS.**
- **Convert comment to docstring; update wording.**
- **Create a fixture to patch-out compiler customization on macOS.**
- **Utilize the fixture for disabling compiler customization on macOS for cxx test. Closes #231.**
- **Limit mutating global state and simply rely on functools.lru_cache to limit the behavior to a single invocation.**
