### PR TITLE
Apply ruff/bugbear rules (B)

### DIFF
--- a/distutils/command/config.py
+++ b/distutils/command/config.py
@@ -328,7 +328,7 @@ class config(Command):
         library_dirs=None,
         headers=None,
         include_dirs=None,
-        other_libraries: Sequence[str] = [],
+        other_libraries: Sequence[str] = (),
     ):
         """Determine if 'library' is available to be linked against,
         without actually checking that any particular symbols are provided

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -449,7 +449,7 @@ class OptionDummy:
     """Dummy class just used as a place to hold command-line option
     values as instance attributes."""
 
-    def __init__(self, options: Sequence[Any] = []):
+    def __init__(self, options: Sequence[Any] = ()):
         """Create a new OptionDummy instance.  The attributes listed in
         'options' will be initialized to None."""
         for opt in options:

--- a/distutils/tests/__init__.py
+++ b/distutils/tests/__init__.py
@@ -10,7 +10,7 @@ by import rather than matching pre-defined names.
 from typing import Sequence
 
 
-def missing_compiler_executable(cmd_names: Sequence[str] = []):  # pragma: no cover
+def missing_compiler_executable(cmd_names: Sequence[str] = ()):  # pragma: no cover
     """Check if the compiler components used to build the interpreter exist.
 
     Check for the existence of the compiler executables whose names are listed


### PR DESCRIPTION
Start addressing #240.
```
B006 Do not use mutable data structures for argument defaults
````    
https://docs.astral.sh/ruff/rules/mutable-argument-default/

<!--
````    
B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
````    
https://docs.astral.sh/ruff/rules/assert-false/

````    
B015 Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it.
````    
https://docs.astral.sh/ruff/rules/useless-comparison/

````    
B020 Loop control variable `value` overrides iterable it iterates
````    
https://docs.astral.sh/ruff/rules/loop-variable-overrides-iterator/
-->

Don't apply this rule:
````    
B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
````    
https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/
