### PR TITLE
Extend Windows system executable extensions

### DIFF
--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -110,7 +110,9 @@ def find_executable(executable, path=None):
     if os.path.isfile(executable):
         return executable
 
-    for p in _search_paths(path):
-        for exe in filter(pathlib.Path.is_file, _executable_candidates(p / executable)):
-            return os.fspath(exe)
-    return None
+    found = (
+        os.fspath(exe)
+        for p in _search_paths(path)
+        for exe in filter(pathlib.Path.is_file, _executable_candidates(p / executable))
+    )
+    return next(found, None)

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -77,9 +77,9 @@ def _executable_candidates(executable: pathlib.Path):
     yield executable
     if platform.system() != 'Windows':
         return
-    exts = os.environ.get('PATHEXT').lower().split(os.pathsep)
-    for ext in filter(executable.suffix.__ne__, exts):
-        yield executable.with_suffix(ext)
+    exts = os.environ.get('PATHEXT').split(os.pathsep)
+    unique = (ext for ext in exts if executable.suffix.casefold() != ext.casefold())
+    yield from map(executable.with_suffix, unique)
 
 
 def _search_paths(path):

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -75,8 +75,11 @@ def find_executable(executable, path=None):
     os.environ['PATH'].  Returns the complete filename or None if not found.
     """
     _, ext = os.path.splitext(executable)
-    if (sys.platform == 'win32') and (ext != '.exe'):
-        executable = executable + '.exe'
+    executable_candidates = [executable]
+    if (sys.platform == 'win32'):
+        exts = os.environ.get('PATHEXT').lower().split(os.pathsep)
+        if (ext not in exts):
+            executable_candidates = [executable + ext for ext in exts]
 
     if os.path.isfile(executable):
         return executable
@@ -98,8 +101,9 @@ def find_executable(executable, path=None):
 
     paths = path.split(os.pathsep)
     for p in paths:
-        f = os.path.join(p, executable)
-        if os.path.isfile(f):
-            # the file exists, we have a shot at spawn working
-            return f
+        for executable_candidate in executable_candidates:
+            f = os.path.join(p, executable_candidate)
+            if os.path.isfile(f):
+                # the file exists, we have a shot at spawn working
+                return f
     return None

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -82,15 +82,7 @@ def _executable_candidates(executable: pathlib.Path):
         yield executable.with_suffix(ext)
 
 
-def find_executable(executable, path=None):
-    """Tries to find 'executable' in the directories listed in 'path'.
-
-    A string listing directories separated by 'os.pathsep'; defaults to
-    os.environ['PATH'].  Returns the complete filename or None if not found.
-    """
-    if os.path.isfile(executable):
-        return executable
-
+def _search_paths(path):
     if path is None:
         path = os.environ.get('PATH', None)
         if path is None:
@@ -104,9 +96,21 @@ def find_executable(executable, path=None):
 
     # PATH='' doesn't match, whereas PATH=':' looks in the current directory
     if not path:
-        return None
+        return ()
 
-    for p in map(pathlib.Path, path.split(os.pathsep)):
+    return map(pathlib.Path, path.split(os.pathsep))
+
+
+def find_executable(executable, path=None):
+    """Tries to find 'executable' in the directories listed in 'path'.
+
+    A string listing directories separated by 'os.pathsep'; defaults to
+    os.environ['PATH'].  Returns the complete filename or None if not found.
+    """
+    if os.path.isfile(executable):
+        return executable
+
+    for p in _search_paths(path):
         for exe in filter(pathlib.Path.is_file, _executable_candidates(p / executable)):
             return os.fspath(exe)
     return None

--- a/distutils/tests/test_spawn.py
+++ b/distutils/tests/test_spawn.py
@@ -45,14 +45,9 @@ class TestSpawn(support.TempdirManager):
         spawn([exe])  # should work without any error
 
     def test_find_executable(self, tmp_path):
-        program_noeext = 'program'
-        # Give the temporary program an ".exe" suffix for all.
-        # It's needed on Windows and not harmful on other platforms.
-        program = program_noeext + ".exe"
-
-        program_path = tmp_path / program
-        program_path.write_text("", encoding='utf-8')
-        program_path.chmod(stat.S_IXUSR)
+        program_path = self._make_executable(tmp_path, '.exe')
+        program = program_path.name
+        program_noeext = program_path.with_suffix('').name
         filename = str(program_path)
         tmp_dir = path.Path(tmp_path)
 
@@ -120,6 +115,15 @@ class TestSpawn(support.TempdirManager):
             ), mock.patch('distutils.spawn.os.defpath', ''):
                 rv = find_executable(program)
                 assert rv == filename
+
+    @staticmethod
+    def _make_executable(tmp_path, ext):
+        # Give the temporary program a suffix regardless of platform.
+        # It's needed on Windows and not harmful on others.
+        program = tmp_path.joinpath('program').with_suffix(ext)
+        program.write_text("", encoding='utf-8')
+        program.chmod(stat.S_IXUSR)
+        return program
 
     def test_spawn_missing_exe(self):
         with pytest.raises(DistutilsExecError) as ctx:

--- a/distutils/tests/test_spawn.py
+++ b/distutils/tests/test_spawn.py
@@ -57,10 +57,10 @@ class TestSpawn(support.TempdirManager):
         rv = find_executable(program, path=tmp_dir)
         assert rv == filename
 
-        if sys.platform == 'win32':
+        if sys.platform == 'win32':  # pragma: no cover
             # test without ".exe" extension
             rv = find_executable(program_noeext, path=tmp_dir)
-            assert rv == filename
+            assert os.path.samefile(rv, filename)
 
         # test find in the current directory
         with tmp_dir:


### PR DESCRIPTION
For Windows system, the `find_executable` function is hardcoded with `.exe` to locate the executable file.
Windows has a list of execution extensions, which tells by the environment variable `PATHEXT`.
The pull request is aiming to fix the following use case,

```
>>> find_executable("apktool")
*Returns None*
```
The pull request aims to locate the first matched executable
```
>>> find_executable("apktool")
'C:\\bin\\apktool.bat'
```