### PR TITLE
Use a separate build directory for free-threading

### DIFF
--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -4,6 +4,7 @@ Implements the Distutils 'build' command."""
 
 import os
 import sys
+import sysconfig
 
 from ..core import Command
 from ..errors import DistutilsOptionError
@@ -80,6 +81,10 @@ class build(Command):
                 )
 
         plat_specifier = f".{self.plat_name}-{sys.implementation.cache_tag}"
+
+        # Python 3.13+ with --disable-gil shouldn't share build directories
+        if sysconfig.get_config_var('Py_GIL_DISABLED'):
+            plat_specifier += 't'
 
         # Make it so Python 2.x and Python 2.x with --with-pydebug don't
         # share the same build directories. Doing so confuses the build

--- a/distutils/tests/test_build.py
+++ b/distutils/tests/test_build.py
@@ -4,6 +4,7 @@ import os
 import sys
 from distutils.command.build import build
 from distutils.tests import support
+from sysconfig import get_config_var
 from sysconfig import get_platform
 
 
@@ -24,6 +25,8 @@ class TestBuild(support.TempdirManager):
         # examples:
         #   build/lib.macosx-10.3-i386-cpython39
         plat_spec = f'.{cmd.plat_name}-{sys.implementation.cache_tag}'
+        if get_config_var('Py_GIL_DISABLED'):
+            plat_spec += 't'
         if hasattr(sys, 'gettotalrefcount'):
             assert cmd.build_platlib.endswith('-pydebug')
             plat_spec += '-pydebug'


### PR DESCRIPTION
Hello!

I work on the [drgn debugger](https://github.com/osandov/drgn), and with the recently added 3.13t builds in the manylinux docker, which enable the `--disable-gil` option, we started getting some build failures when building wheels. It turned out that the standard and free-threading builds of 3.13 both use the same `build_temp` and `build_lib` directories.

Drgn has a bit of a customized build system which allows incremental builds within the `build_temp` directory, so the object files from 3.13 were getting reused for the free-threaded build, but the ABI is not compatible anymore. The result was an extension that segfaulted immediately on import.

It seems that a standard distutils extension doesn't have incremental build support, so maybe overlapping `build_temp` and `build_lib` directories isn't a huge problem. But looking through the code, it seems like distutils tries to avoid overlapping these `build_temp` and `build_lib` directories where the compiler could get confused or produce incorrect results. So I thought this might be a suitable fix for distutils itself, rather than just in drgn's build system.

Thanks!