### PR TITLE
Use brackets for the default value of option arguments

### DIFF
--- a/distutils/command/bdist.py
+++ b/distutils/command/bdist.py
@@ -41,7 +41,7 @@ class bdist(Command):
             'plat-name=',
             'p',
             "platform name to embed in generated filenames "
-            f"(default: {get_platform()})",
+            f"[default: {get_platform()}]",
         ),
         ('formats=', None, "formats for distribution (comma-separated list)"),
         (

--- a/distutils/command/bdist_dumb.py
+++ b/distutils/command/bdist_dumb.py
@@ -23,7 +23,7 @@ class bdist_dumb(Command):
             'plat-name=',
             'p',
             "platform name to embed in generated filenames "
-            f"(default: {get_platform()})",
+            f"[default: {get_platform()}]",
         ),
         (
             'format=',
@@ -40,7 +40,7 @@ class bdist_dumb(Command):
         (
             'relative',
             None,
-            "build the archive using relative paths (default: false)",
+            "build the archive using relative paths [default: false]",
         ),
         (
             'owner=',

--- a/distutils/command/bdist_rpm.py
+++ b/distutils/command/bdist_rpm.py
@@ -40,7 +40,7 @@ class bdist_rpm(Command):
             'python=',
             None,
             "path to Python interpreter to hard-code in the .spec file "
-            "(default: \"python\")",
+            "[default: \"python\"]",
         ),
         (
             'fix-python',

--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -34,7 +34,7 @@ class build(Command):
         (
             'plat-name=',
             'p',
-            f"platform name to build for, if supported (default: {get_platform()})",
+            f"platform name to build for, if supported [default: {get_platform()}]",
         ),
         ('compiler=', 'c', "specify the compiler type"),
         ('parallel=', 'j', "number of parallel build jobs"),

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -65,7 +65,7 @@ class build_ext(Command):
             'plat-name=',
             'p',
             "platform name to cross-compile for, if supported "
-            f"(default: {get_platform()})",
+            f"[default: {get_platform()}]",
         ),
         (
             'inplace',

--- a/distutils/command/clean.py
+++ b/distutils/command/clean.py
@@ -14,17 +14,17 @@ from ..dir_util import remove_tree
 class clean(Command):
     description = "clean up temporary files from 'build' command"
     user_options = [
-        ('build-base=', 'b', "base build directory (default: 'build.build-base')"),
+        ('build-base=', 'b', "base build directory [default: 'build.build-base']"),
         (
             'build-lib=',
             None,
-            "build directory for all modules (default: 'build.build-lib')",
+            "build directory for all modules [default: 'build.build-lib']",
         ),
-        ('build-temp=', 't', "temporary build directory (default: 'build.build-temp')"),
+        ('build-temp=', 't', "temporary build directory [default: 'build.build-temp']"),
         (
             'build-scripts=',
             None,
-            "build directory for scripts (default: 'build.build-scripts')",
+            "build directory for scripts [default: 'build.build-scripts']",
         ),
         ('bdist-base=', None, "temporary directory for built distributions"),
         ('all', 'a', "remove all build output, not just temporary by-products"),

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -19,7 +19,7 @@ class install_data(Command):
             'install-dir=',
             'd',
             "base directory for installing data files "
-            "(default: installation base dir)",
+            "[default: installation base dir]",
         ),
         ('root=', None, "install everything relative to this alternate root directory"),
         ('force', 'f', "force installation (overwrite existing files)"),


### PR DESCRIPTION
The goal is to standardize the format of the help text printed by commands. It's not easy to choose between brackets `[]` and parentheses `()`. I went for the [docopt](http://docopt.org/) style, which is the closest to a standard I could find:

> [...] and whether that argument has a default value (**`[default: 10]`**).

Fixes #251.