### PR TITLE
Enforce ruff/flake8-2020 rule (YTT301)

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -236,7 +236,7 @@ def get_python_lib(plat_specific=False, standard_lib=False, prefix=None):
         if prefix is None:
             prefix = PREFIX
         if standard_lib:
-            return os.path.join(prefix, "lib-python", sys.version[0])
+            return os.path.join(prefix, "lib-python", sys.version_info.major)
         return os.path.join(prefix, 'site-packages')
 
     early_prefix = prefix

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,6 +9,7 @@ extend-select = [
 	"RUF010",
 	"RUF100",
 	"UP",
+	"YTT",
 ]
 ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules


### PR DESCRIPTION
```
YTT301 `sys.version[0]` referenced (python10), use `sys.version_info`
```
The Python documentation discourages the use of `sys.version`:
> Do not extract version information out of it, rather, use [`version_info`](https://docs.python.org/3/library/sys.html#sys.version_info) and the functions provided by the [`platform`](https://docs.python.org/3/library/platform.html#module-platform) module.