### PR TITLE
Enforce ruff/Perflint rules (PERF)

### DIFF
--- a/distutils/archive_util.py
+++ b/distutils/archive_util.py
@@ -266,8 +266,7 @@ def make_archive(
         raise ValueError(f"unknown archive format '{format}'")
 
     func = format_info[0]
-    for arg, val in format_info[1]:
-        kwargs[arg] = val
+    kwargs.update(format_info[1])
 
     if format != 'zip':
         kwargs['owner'] = owner

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -638,8 +638,7 @@ class build_ext(Command):
 
         # Do not override commandline arguments
         if not self.swig_opts:
-            for o in extension.swig_opts:
-                swig_cmd.append(o)
+            swig_cmd.extend(extension.swig_opts)
 
         for source in swig_sources:
             target = swig_targets[source]

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -680,7 +680,7 @@ class install(Command):
         if not self.user:
             return
         home = convert_path(os.path.expanduser("~"))
-        for _name, path in self.config_vars.items():
+        for path in self.config_vars.values():
             if str(path).startswith(home) and not os.path.isdir(path):
                 self.debug_print(f"os.makedirs('{path}', 0o700)")
                 os.makedirs(path, 0o700)

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -172,8 +172,7 @@ class CygwinCCompiler(UnixCCompiler):
 
             # Generate .def file
             contents = [f"LIBRARY {os.path.basename(output_filename)}", "EXPORTS"]
-            for sym in export_symbols:
-                contents.append(sym)
+            contents.extend(export_symbols)
             self.execute(write_file, (def_file, contents), f"writing {def_file}")
 
             # next add options for def-file

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -741,9 +741,7 @@ Common commands: (see '--help-commands' for more)
         import distutils.command
 
         std_commands = distutils.command.__all__
-        is_std = set()
-        for cmd in std_commands:
-            is_std.add(cmd)
+        is_std = set(std_commands)
 
         extra_commands = [cmd for cmd in self.cmdclass.keys() if cmd not in is_std]
 
@@ -769,9 +767,7 @@ Common commands: (see '--help-commands' for more)
         import distutils.command
 
         std_commands = distutils.command.__all__
-        is_std = set()
-        for cmd in std_commands:
-            is_std.add(cmd)
+        is_std = set(std_commands)
 
         extra_commands = [cmd for cmd in self.cmdclass.keys() if cmd not in is_std]
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,7 +14,9 @@ extend-select = [
 	"UP",
 ]
 ignore = [
+	# local
 	"PERF203",
+
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",
 	"E111",

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,11 +8,13 @@ extend-select = [
 	"B",
 	"I",
 	"ISC",
+	"PERF",
 	"RUF010",
 	"RUF100",
 	"UP",
 ]
 ignore = [
+	"PERF203",
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",
 	"E111",


### PR DESCRIPTION
I have not applied this one:
```
PERF203 `try`-`except` within a loop incurs performance overhead
```
I believe the rest of the changes result in more readable code, but I am not certain about this one. In the absence of measured performance gains, I have left it out. I am happy to apply the [`PERF203`](https://docs.astral.sh/ruff/rules/try-except-in-loop/) rule as well if you want me too.