### PR TITLE
sysconfig: skip customize_compiler() with MSVC Python again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,9 @@ jobs:
             git
       - name: Install Dependencies
         shell: msys2 {0}
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         run: |
           export VIRTUALENV_NO_SETUPTOOLS=1
 

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -293,7 +293,9 @@ def customize_compiler(compiler):  # noqa: C901
     Mainly needed on Unix, so we can plug in the information that
     varies across Unices and is stored in Python's Makefile.
     """
-    if compiler.compiler_type in ["unix", "cygwin", "mingw32"]:
+    if compiler.compiler_type in ["unix", "cygwin"] or (
+        compiler.compiler_type == "mingw32" and is_mingw()
+    ):
         _customize_macos()
 
         (

--- a/distutils/tests/test_mingwccompiler.py
+++ b/distutils/tests/test_mingwccompiler.py
@@ -2,6 +2,7 @@ import pytest
 
 from distutils.util import split_quoted, is_mingw
 from distutils.errors import DistutilsPlatformError, CCompilerError
+from distutils import sysconfig
 
 
 class TestMingw32CCompiler:
@@ -43,3 +44,12 @@ class TestMingw32CCompiler:
 
         with pytest.raises(CCompilerError):
             distutils.cygwinccompiler.Mingw32CCompiler()
+
+    def test_customize_compiler_with_msvc_python(self):
+        from distutils.cygwinccompiler import Mingw32CCompiler
+
+        # In case we have an MSVC Python build, but still want to use
+        # Mingw32CCompiler, then customize_compiler() shouldn't fail at least.
+        # https://github.com/pypa/setuptools/issues/4456
+        compiler = Mingw32CCompiler()
+        sysconfig.customize_compiler(compiler)


### PR DESCRIPTION
By enabling customize_compiler() when using the mingw compiler class
in https://github.com/pypa/distutils/commit/2ad8784dfeb816829995613fb5fd9818f3e88922 this also enabled it for when the mingw compiler
class was used with a MSVC built CPython.

MSVC CPython doesn't have any of the config vars that are required in
customize_compiler() though. And while it would be nice if all the env
vars would be considered in that scenario too, it's not clear how this
should be implemented without any sysconfig provided fallbacks
(if CC isn't set but CFLAGS is, there is no way to pass things to
set_executables() etc.)

Given that, just restore the previous behaviour, skip customize_compiler()
with MSVC Python in all cases, and add a test.

Fixes https://github.com/pypa/distutils/issues/268