### PR TITLE
Allow path objects for data-files

### DIFF
--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -5,11 +5,17 @@ platform-independent data files."""
 
 # contributed by Bastian Kleineidam
 
+import functools
 import os
 import pathlib
 
+from typing import Tuple, Iterable
+
 from ..core import Command
 from ..util import change_root, convert_path
+
+
+StrPath = str | pathlib.Path
 
 
 class install_data(Command):
@@ -47,36 +53,41 @@ class install_data(Command):
     def run(self):
         self.mkpath(self.install_dir)
         for f in self.data_files:
-            if isinstance(f, (str, pathlib.Path)):
-                # it's a simple file, so copy it
-                f = convert_path(f)
-                if self.warn_dir:
-                    self.warn(
-                        "setup script did not provide a directory for "
-                        f"'{f}' -- installing right in '{self.install_dir}'"
-                    )
-                (out, _) = self.copy_file(f, self.install_dir)
-                self.outfiles.append(out)
-            else:
-                # it's a tuple with path to install to and a list of files
-                dir = convert_path(f[0])
-                if not os.path.isabs(dir):
-                    dir = os.path.join(self.install_dir, dir)
-                elif self.root:
-                    dir = change_root(self.root, dir)
-                self.mkpath(dir)
+            self._copy(f)
 
-                if f[1] == []:
-                    # If there are no files listed, the user must be
-                    # trying to create an empty directory, so add the
-                    # directory to the list of output files.
-                    self.outfiles.append(dir)
-                else:
-                    # Copy files, adding them to the list of output files.
-                    for data in f[1]:
-                        data = convert_path(data)
-                        (out, _) = self.copy_file(data, dir)
-                        self.outfiles.append(out)
+    @functools.singledispatchmethod
+    def _copy(self, f: StrPath | Tuple[StrPath, Iterable[StrPath]]):
+        # it's a tuple with path to install to and a list of files
+        dir = convert_path(f[0])
+        if not os.path.isabs(dir):
+            dir = os.path.join(self.install_dir, dir)
+        elif self.root:
+            dir = change_root(self.root, dir)
+        self.mkpath(dir)
+
+        if f[1] == []:
+            # If there are no files listed, the user must be
+            # trying to create an empty directory, so add the
+            # directory to the list of output files.
+            self.outfiles.append(dir)
+        else:
+            # Copy files, adding them to the list of output files.
+            for data in f[1]:
+                data = convert_path(data)
+                (out, _) = self.copy_file(data, dir)
+                self.outfiles.append(out)
+
+    @_copy.register
+    def _(self, f: StrPath):
+        # it's a simple file, so copy it
+        f = convert_path(f)
+        if self.warn_dir:
+            self.warn(
+                "setup script did not provide a directory for "
+                f"'{f}' -- installing right in '{self.install_dir}'"
+            )
+        (out, _) = self.copy_file(f, self.install_dir)
+        self.outfiles.append(out)
 
     def get_inputs(self):
         return self.data_files or []

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -6,7 +6,7 @@ platform-independent data files."""
 # contributed by Bastian Kleineidam
 
 import os
-from pathlib import Path
+import pathlib
 
 from ..core import Command
 from ..util import change_root, convert_path
@@ -47,7 +47,7 @@ class install_data(Command):
     def run(self):
         self.mkpath(self.install_dir)
         for f in self.data_files:
-            if isinstance(f, (str, Path)):
+            if isinstance(f, (str, pathlib.Path)):
                 # it's a simple file, so copy it
                 f = convert_path(f)
                 if self.warn_dir:

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -6,6 +6,7 @@ platform-independent data files."""
 # contributed by Bastian Kleineidam
 
 import os
+from pathlib import Path
 
 from ..core import Command
 from ..util import change_root, convert_path
@@ -49,6 +50,16 @@ class install_data(Command):
             if isinstance(f, str):
                 # it's a simple file, so copy it
                 f = convert_path(f)
+                if self.warn_dir:
+                    self.warn(
+                        "setup script did not provide a directory for "
+                        f"'{f}' -- installing right in '{self.install_dir}'"
+                    )
+                (out, _) = self.copy_file(f, self.install_dir)
+                self.outfiles.append(out)
+            elif isinstance(f, Path):
+                # it's a simple file, so copy it
+                f = convert_path(str(f))
                 if self.warn_dir:
                     self.warn(
                         "setup script did not provide a directory for "

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -47,19 +47,9 @@ class install_data(Command):
     def run(self):
         self.mkpath(self.install_dir)
         for f in self.data_files:
-            if isinstance(f, str):
+            if isinstance(f, (str, Path)):
                 # it's a simple file, so copy it
-                f = convert_path(f)
-                if self.warn_dir:
-                    self.warn(
-                        "setup script did not provide a directory for "
-                        f"'{f}' -- installing right in '{self.install_dir}'"
-                    )
-                (out, _) = self.copy_file(f, self.install_dir)
-                self.outfiles.append(out)
-            elif isinstance(f, Path):
-                # it's a simple file, so copy it
-                f = convert_path(str(f))
+                f = convert_path(os.fspath(f))
                 if self.warn_dir:
                     self.warn(
                         "setup script did not provide a directory for "

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -5,17 +5,15 @@ platform-independent data files."""
 
 # contributed by Bastian Kleineidam
 
+from __future__ import annotations
+
 import functools
 import os
-import pathlib
 
-from typing import Tuple, Iterable
+from typing import Iterable
 
 from ..core import Command
 from ..util import change_root, convert_path
-
-
-StrPath = str | pathlib.Path
 
 
 class install_data(Command):
@@ -56,7 +54,7 @@ class install_data(Command):
             self._copy(f)
 
     @functools.singledispatchmethod
-    def _copy(self, f: StrPath | Tuple[StrPath, Iterable[StrPath]]):
+    def _copy(self, f: tuple[str | os.PathLike, Iterable[str | os.PathLike]]):
         # it's a tuple with path to install to and a list of files
         dir = convert_path(f[0])
         if not os.path.isabs(dir):
@@ -77,8 +75,9 @@ class install_data(Command):
                 (out, _) = self.copy_file(data, dir)
                 self.outfiles.append(out)
 
-    @_copy.register
-    def _(self, f: StrPath):
+    @_copy.register(str)
+    @_copy.register(os.PathLike)
+    def _(self, f: str | os.PathLike):
         # it's a simple file, so copy it
         f = convert_path(f)
         if self.warn_dir:

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -49,7 +49,7 @@ class install_data(Command):
         for f in self.data_files:
             if isinstance(f, (str, Path)):
                 # it's a simple file, so copy it
-                f = convert_path(os.fspath(f))
+                f = convert_path(f)
                 if self.warn_dir:
                     self.warn(
                         "setup script did not provide a directory for "

--- a/distutils/tests/test_install_data.py
+++ b/distutils/tests/test_install_data.py
@@ -1,11 +1,12 @@
 """Tests for distutils.command.install_data."""
 
 import os
-from pathlib import Path
-from distutils.command.install_data import install_data
-from distutils.tests import support
+import pathlib
 
 import pytest
+
+from distutils.command.install_data import install_data
+from distutils.tests import support
 
 
 @pytest.mark.usefixtures('save_env')
@@ -26,7 +27,7 @@ class TestInstallData(
         inst2 = os.path.join(pkg_dir, 'inst2')
         two = os.path.join(pkg_dir, 'two')
         self.write_file(two, 'xxx')
-        three = Path(pkg_dir) / 'three'
+        three = pathlib.Path(pkg_dir) / 'three'
         self.write_file(three, 'xxx')
 
         cmd.data_files = [one, (inst2, [two]), three]

--- a/distutils/tests/test_install_data.py
+++ b/distutils/tests/test_install_data.py
@@ -1,6 +1,7 @@
 """Tests for distutils.command.install_data."""
 
 import os
+from pathlib import Path
 from distutils.command.install_data import install_data
 from distutils.tests import support
 
@@ -18,22 +19,27 @@ class TestInstallData(
 
         # data_files can contain
         #  - simple files
+        #  - a Path object
         #  - a tuple with a path, and a list of file
         one = os.path.join(pkg_dir, 'one')
         self.write_file(one, 'xxx')
         inst2 = os.path.join(pkg_dir, 'inst2')
         two = os.path.join(pkg_dir, 'two')
         self.write_file(two, 'xxx')
+        three = Path(pkg_dir) / 'three'
+        self.write_file(three, 'xxx')
 
-        cmd.data_files = [one, (inst2, [two])]
-        assert cmd.get_inputs() == [one, (inst2, [two])]
+        cmd.data_files = [one, (inst2, [two]), three]
+        assert cmd.get_inputs() == [one, (inst2, [two]), three]
 
         # let's run the command
         cmd.ensure_finalized()
         cmd.run()
 
         # let's check the result
-        assert len(cmd.get_outputs()) == 2
+        assert len(cmd.get_outputs()) == 3
+        rthree = os.path.split(one)[-1]
+        assert os.path.exists(os.path.join(inst, rthree))
         rtwo = os.path.split(two)[-1]
         assert os.path.exists(os.path.join(inst2, rtwo))
         rone = os.path.split(one)[-1]
@@ -46,21 +52,23 @@ class TestInstallData(
         cmd.run()
 
         # let's check the result
-        assert len(cmd.get_outputs()) == 2
+        assert len(cmd.get_outputs()) == 3
+        assert os.path.exists(os.path.join(inst, rthree))
         assert os.path.exists(os.path.join(inst2, rtwo))
         assert os.path.exists(os.path.join(inst, rone))
         cmd.outfiles = []
 
         # now using root and empty dir
         cmd.root = os.path.join(pkg_dir, 'root')
-        inst4 = os.path.join(pkg_dir, 'inst4')
-        three = os.path.join(cmd.install_dir, 'three')
-        self.write_file(three, 'xx')
-        cmd.data_files = [one, (inst2, [two]), ('inst3', [three]), (inst4, [])]
+        inst5 = os.path.join(pkg_dir, 'inst5')
+        four = os.path.join(cmd.install_dir, 'four')
+        self.write_file(four, 'xx')
+        cmd.data_files = [one, (inst2, [two]), ('inst5', [four]), (inst5, [])]
         cmd.ensure_finalized()
         cmd.run()
 
         # let's check the result
-        assert len(cmd.get_outputs()) == 4
+        assert len(cmd.get_outputs()) == 5
+        assert os.path.exists(os.path.join(inst, rthree))
         assert os.path.exists(os.path.join(inst2, rtwo))
         assert os.path.exists(os.path.join(inst, rone))

--- a/distutils/tests/test_install_data.py
+++ b/distutils/tests/test_install_data.py
@@ -63,7 +63,7 @@ class TestInstallData(
         inst5 = os.path.join(pkg_dir, 'inst5')
         four = os.path.join(cmd.install_dir, 'four')
         self.write_file(four, 'xx')
-        cmd.data_files = [one, (inst2, [two]), ('inst5', [four]), (inst5, [])]
+        cmd.data_files = [one, (inst2, [two]), three, ('inst5', [four]), (inst5, [])]
         cmd.ensure_finalized()
         cmd.run()
 

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -63,16 +63,10 @@ class TestUtil:
             with mock.patch.dict('os.environ', {'VSCMD_ARG_TGT_ARCH': 'arm64'}):
                 assert get_platform() == 'win-arm64'
 
-    @pytest.mark.skipif('platform.system() == "Windows"')
-    def test_convert_path_unix(self):
-        assert convert_path('/home/to/my/stuff') == '/home/to/my/stuff'
-        assert convert_path(pathlib.Path('/home/to/my/stuff')) == '/home/to/my/stuff'
-        assert convert_path('.') == os.curdir
-
-    @pytest.mark.skipif('platform.system() != "Windows"')
-    def test_convert_path_windows(self):
-        assert convert_path('/home/to/my/stuff') == r'\home\to\my\stuff'
-        assert convert_path(pathlib.Path('/home/to/my/stuff')) == r'\home\to\my\stuff'
+    def test_convert_path(self):
+        expected = os.sep.join(('', 'home', 'to', 'my', 'stuff'))
+        assert convert_path('/home/to/my/stuff') == expected
+        assert convert_path(pathlib.Path('/home/to/my/stuff')) == expected
         assert convert_path('.') == os.curdir
 
     def test_change_root(self):

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -5,6 +5,7 @@ import email.generator
 import email.policy
 import io
 import os
+import pathlib
 import sys
 import sysconfig as stdlib_sysconfig
 import unittest.mock as mock
@@ -72,6 +73,7 @@ class TestUtil:
         os.path.join = _join
 
         assert convert_path('/home/to/my/stuff') == '/home/to/my/stuff'
+        assert convert_path(pathlib.Path('/home/to/my/stuff')) == '/home/to/my/stuff'
 
         # win
         os.sep = '\\'
@@ -85,8 +87,11 @@ class TestUtil:
             convert_path('/home/to/my/stuff')
         with pytest.raises(ValueError):
             convert_path('home/to/my/stuff/')
+        with pytest.raises(ValueError):
+            convert_path(pathlib.Path('/home/to/my/stuff'))
 
         assert convert_path('home/to/my/stuff') == 'home\\to\\my\\stuff'
+        assert convert_path(pathlib.Path('home/to/my/stuff')) == 'home\\to\\my\\stuff'
         assert convert_path('.') == os.curdir
 
     def test_change_root(self):

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -4,10 +4,8 @@ import email
 import email.generator
 import email.policy
 import io
-import ntpath
 import os
 import pathlib
-import posixpath
 import sys
 import sysconfig as stdlib_sysconfig
 import unittest.mock as mock
@@ -65,17 +63,13 @@ class TestUtil:
             with mock.patch.dict('os.environ', {'VSCMD_ARG_TGT_ARCH': 'arm64'}):
                 assert get_platform() == 'win-arm64'
 
+    @pytest.mark.skipif('platform.system() == "Windows"')
     def test_convert_path_unix(self):
-        os.sep = '/'
-        os.path.join = posixpath.join
-
         assert convert_path('/home/to/my/stuff') == '/home/to/my/stuff'
         assert convert_path(pathlib.Path('/home/to/my/stuff')) == '/home/to/my/stuff'
 
+    @pytest.mark.skipif('platform.system() != "Windows"')
     def test_convert_path_windows(self):
-        os.sep = '\\'
-        os.path.join = ntpath.join
-
         assert convert_path('home/to/my/stuff') == 'home\\to\\my\\stuff'
         assert convert_path(pathlib.Path('home/to/my/stuff')) == 'home\\to\\my\\stuff'
         assert convert_path('.') == os.curdir

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -76,11 +76,6 @@ class TestUtil:
         os.sep = '\\'
         os.path.join = ntpath.join
 
-        with pytest.raises(ValueError):
-            convert_path('/home/to/my/stuff')
-        with pytest.raises(ValueError):
-            convert_path(pathlib.Path('/home/to/my/stuff'))
-
         assert convert_path('home/to/my/stuff') == 'home\\to\\my\\stuff'
         assert convert_path(pathlib.Path('home/to/my/stuff')) == 'home\\to\\my\\stuff'
         assert convert_path('.') == os.curdir

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -67,11 +67,12 @@ class TestUtil:
     def test_convert_path_unix(self):
         assert convert_path('/home/to/my/stuff') == '/home/to/my/stuff'
         assert convert_path(pathlib.Path('/home/to/my/stuff')) == '/home/to/my/stuff'
+        assert convert_path('.') == os.curdir
 
     @pytest.mark.skipif('platform.system() != "Windows"')
     def test_convert_path_windows(self):
-        assert convert_path('home/to/my/stuff') == 'home\\to\\my\\stuff'
-        assert convert_path(pathlib.Path('home/to/my/stuff')) == 'home\\to\\my\\stuff'
+        assert convert_path('/home/to/my/stuff') == r'\home\to\my\stuff'
+        assert convert_path(pathlib.Path('/home/to/my/stuff')) == r'\home\to\my\stuff'
         assert convert_path('.') == os.curdir
 
     def test_change_root(self):

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -65,15 +65,14 @@ class TestUtil:
             with mock.patch.dict('os.environ', {'VSCMD_ARG_TGT_ARCH': 'arm64'}):
                 assert get_platform() == 'win-arm64'
 
-    def test_convert_path(self):
-        # linux/mac
+    def test_convert_path_unix(self):
         os.sep = '/'
         os.path.join = posixpath.join
 
         assert convert_path('/home/to/my/stuff') == '/home/to/my/stuff'
         assert convert_path(pathlib.Path('/home/to/my/stuff')) == '/home/to/my/stuff'
 
-        # win
+    def test_convert_path_windows(self):
         os.sep = '\\'
         os.path.join = ntpath.join
 

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -4,8 +4,10 @@ import email
 import email.generator
 import email.policy
 import io
+import ntpath
 import os
 import pathlib
+import posixpath
 import sys
 import sysconfig as stdlib_sysconfig
 import unittest.mock as mock
@@ -66,22 +68,14 @@ class TestUtil:
     def test_convert_path(self):
         # linux/mac
         os.sep = '/'
-
-        def _join(path):
-            return '/'.join(path)
-
-        os.path.join = _join
+        os.path.join = posixpath.join
 
         assert convert_path('/home/to/my/stuff') == '/home/to/my/stuff'
         assert convert_path(pathlib.Path('/home/to/my/stuff')) == '/home/to/my/stuff'
 
         # win
         os.sep = '\\'
-
-        def _join(*path):
-            return '\\'.join(path)
-
-        os.path.join = _join
+        os.path.join = ntpath.join
 
         with pytest.raises(ValueError):
             convert_path('/home/to/my/stuff')

--- a/distutils/tests/test_util.py
+++ b/distutils/tests/test_util.py
@@ -80,8 +80,6 @@ class TestUtil:
         with pytest.raises(ValueError):
             convert_path('/home/to/my/stuff')
         with pytest.raises(ValueError):
-            convert_path('home/to/my/stuff/')
-        with pytest.raises(ValueError):
             convert_path(pathlib.Path('/home/to/my/stuff'))
 
         assert convert_path('home/to/my/stuff') == 'home\\to\\my\\stuff'

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 import importlib.util
 import os
+import pathlib
 import re
 import string
 import subprocess
@@ -130,7 +131,9 @@ def convert_path(pathname: str | os.PathLike) -> str:
     >>> convert_path(None) is None
     True
     """
-    return make_native(os.fspath(pathname))
+    # wrap in PurePosixPath to retain forward slashes on Windows
+    # see https://github.com/pypa/distutils/pull/272#issuecomment-2240100013
+    return make_native(os.fspath(pathlib.PurePosixPath(pathname)))
 
 
 def make_native(pathname: str) -> str:

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -16,6 +16,7 @@ import sys
 import sysconfig
 import tempfile
 
+from ._functools import pass_none
 from ._log import log
 from ._modified import newer
 from .errors import DistutilsByteCompileError, DistutilsPlatformError
@@ -118,9 +119,16 @@ def split_version(s):
     return [int(n) for n in s.split('.')]
 
 
+@pass_none
 def convert_path(pathname: str | os.PathLike) -> str:
     """
     Allow for pathlib.Path inputs and then make native.
+
+    Also if None is passed, will just pass it through as
+    Setuptools relies on this behavior.
+
+    >>> convert_path(None) is None
+    True
     """
     return make_native(os.fspath(pathname))
 

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import functools
 import importlib.util
 import os
-import pathlib
 import re
 import string
 import subprocess
@@ -119,7 +118,7 @@ def split_version(s):
     return [int(n) for n in s.split('.')]
 
 
-def convert_path(pathname: str | pathlib.Path) -> str:
+def convert_path(pathname: str | os.PathLike) -> str:
     """
     Allow for pathlib.Path inputs and then make native.
     """

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -122,43 +122,21 @@ def split_version(s):
 
 @pass_none
 def convert_path(pathname: str | os.PathLike) -> str:
-    """
-    Allow for pathlib.Path inputs, coax to posix, and then make native.
+    r"""
+    Allow for pathlib.Path inputs, coax to a native path string.
 
     If None is passed, will just pass it through as
     Setuptools relies on this behavior.
 
     >>> convert_path(None) is None
     True
+
+    Removes empty paths.
+
+    >>> convert_path('foo/./bar').replace('\\', '/')
+    'foo/bar'
     """
-    # Use .as_posix() to retain forward slashes on Windows
-    # see https://github.com/pypa/distutils/pull/272#issuecomment-2240100013
-    return make_native(pathlib.Path(pathname).as_posix())
-
-
-def make_native(pathname: str) -> str:
-    """Return 'pathname' as a name that will work on the native filesystem,
-    i.e. split it on '/' and put it back together again using the current
-    directory separator.  Needed because filenames in the setup script are
-    always supplied in Unix style, and have to be converted to the local
-    convention before we can actually use them in the filesystem.  Raises
-    ValueError on non-Unix-ish systems if 'pathname' either starts or
-    ends with a slash.
-    """
-    if os.sep == '/':
-        return pathname
-    if not pathname:
-        return pathname
-
-    paths = pathname.split('/')
-    while '.' in paths:
-        paths.remove('.')
-    if not paths:
-        return os.curdir
-    return os.path.join(*paths)
-
-
-# convert_path ()
+    return os.fspath(pathlib.PurePath(pathname))
 
 
 def change_root(new_root, pathname):

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -7,6 +7,7 @@ one of the other *util.py modules.
 import functools
 import importlib.util
 import os
+import pathlib
 import re
 import string
 import subprocess
@@ -116,7 +117,14 @@ def split_version(s):
     return [int(n) for n in s.split('.')]
 
 
-def convert_path(pathname):
+def convert_path(pathname: str | pathlib.Path) -> str:
+    """
+    Allow for pathlib.Path inputs and then make native.
+    """
+    return make_native(os.fspath(pathname))
+
+
+def make_native(pathname: str) -> str:
     """Return 'pathname' as a name that will work on the native filesystem,
     i.e. split it on '/' and put it back together again using the current
     directory separator.  Needed because filenames in the setup script are

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -149,8 +149,6 @@ def make_native(pathname: str) -> str:
         return pathname
     if not pathname:
         return pathname
-    if pathname[0] == '/':
-        raise ValueError(f"path '{pathname}' cannot be absolute")
 
     paths = pathname.split('/')
     while '.' in paths:

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -123,17 +123,17 @@ def split_version(s):
 @pass_none
 def convert_path(pathname: str | os.PathLike) -> str:
     """
-    Allow for pathlib.Path inputs and then make native.
+    Allow for pathlib.Path inputs, coax to posix, and then make native.
 
-    Also if None is passed, will just pass it through as
+    If None is passed, will just pass it through as
     Setuptools relies on this behavior.
 
     >>> convert_path(None) is None
     True
     """
-    # wrap in PurePosixPath to retain forward slashes on Windows
+    # Use .as_posix() to retain forward slashes on Windows
     # see https://github.com/pypa/distutils/pull/272#issuecomment-2240100013
-    return make_native(os.fspath(pathlib.PurePosixPath(pathname)))
+    return make_native(pathlib.Path(pathname).as_posix())
 
 
 def make_native(pathname: str) -> str:

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -151,8 +151,6 @@ def make_native(pathname: str) -> str:
         return pathname
     if pathname[0] == '/':
         raise ValueError(f"path '{pathname}' cannot be absolute")
-    if pathname[-1] == '/':
-        raise ValueError(f"path '{pathname}' cannot end with '/'")
 
     paths = pathname.split('/')
     while '.' in paths:

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -4,6 +4,8 @@ Miscellaneous utility functions -- anything that doesn't fit into
 one of the other *util.py modules.
 """
 
+from __future__ import annotations
+
 import functools
 import importlib.util
 import os


### PR DESCRIPTION
- **Allow path objects**
- **Need to include 'three' in the input.**
- **Consolidate str and Path handling.**
- **Expand convert_path to also accept pathlib.Path objects.**
- **Prefer simply 'pathlib' for import.**
- **Extract a singledispatchmethod _copy for handling the copy of each data file.**
- **Use explicit registration for compatibility with older Pythons.**
- **Prefer os.PathLike in convert_path**
