### PR TITLE
venv_install_options: add missing clear_argv fixture

### DIFF
--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -88,7 +88,7 @@ class TestDistributionBehavior(support.TempdirManager):
         'distutils' not in Distribution.parse_config_files.__module__,
         reason='Cannot test when virtualenv has monkey-patched Distribution',
     )
-    def test_venv_install_options(self, tmp_path):
+    def test_venv_install_options(self, tmp_path, clear_argv):
         sys.argv.append("install")
         file = str(tmp_path / 'file')
 


### PR DESCRIPTION
Otherwise the test fails if arguments are passed to pytest, for example --no-cov:

FAILED distutils/tests/test_dist.py::TestDistributionBehavior::test_venv_install_options -
      distutils.errors.DistutilsArgError: option --no-cov not recognized