### PR TITLE
Let _show_help() use commands instead of self.commands

### DIFF
--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -658,7 +658,7 @@ Common commands: (see '--help-commands' for more)
             )
             print()
 
-        for command in self.commands:
+        for command in commands:
             if isinstance(command, type) and issubclass(command, Command):
                 klass = command
             else:


### PR DESCRIPTION
Depending on the context, _show_help() is called with a different commands argument. I believe the intent was to adapt the help message to the context. However, it would operate on self.commands instead of the commands argument, which would break this purpose.

Fixes #242.