### PR TITLE
Enforce flake8-bugbear (`B`) and isort (`I`) ruff rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -5,6 +5,8 @@ extend-select = [
 	"W",
 
 	# local
+	"B",
+	"I",
 	"ISC",
 	"RUF010",
 	"RUF100",
@@ -26,6 +28,10 @@ ignore = [
 	"COM819",
 	"ISC001",
 	"ISC002",
+
+	# local
+	"B028",
+	"B904",
 ]
 
 [format]


### PR DESCRIPTION
Ignore `B028` and B904.

Fixes #240.