### PR TITLE
Remove outdated `ImportError` check for `warnings`

### DIFF
--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -14,9 +14,8 @@ import warnings
 from collections.abc import Iterable
 from email import message_from_file
 
-from ._vendor.packaging.utils import canonicalize_name, canonicalize_version
-
 from ._log import log
+from ._vendor.packaging.utils import canonicalize_name, canonicalize_version
 from .debug import DEBUG
 from .errors import (
     DistutilsArgError,

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -10,15 +10,11 @@ import os
 import pathlib
 import re
 import sys
+import warnings
 from collections.abc import Iterable
 from email import message_from_file
 
 from ._vendor.packaging.utils import canonicalize_name, canonicalize_version
-
-try:
-    import warnings
-except ImportError:
-    warnings = None
 
 from ._log import log
 from .debug import DEBUG
@@ -249,10 +245,7 @@ Common commands: (see '--help-commands' for more)
                 attrs['license'] = attrs['licence']
                 del attrs['licence']
                 msg = "'licence' distribution option is deprecated; use 'license'"
-                if warnings is not None:
-                    warnings.warn(msg)
-                else:
-                    sys.stderr.write(msg + "\n")
+                warnings.warn(msg)
 
             # Now work on the rest of the attributes.  Any attribute that's
             # not already defined is invalid!


### PR DESCRIPTION
If I am not mistaken `warnings` is a valid import in any supported version of Python, so there is no need for handling an `ImportError`.


This seems to have been introduced in https://github.com/pypa/distutils/commit/c3c5a89898505fe9b1efe3310fc6a666212bd148, 31th Oct 2002 (so the commit might have been accounting for versions of Python prior to [2.1, which was released on 17th Apr 2001](https://docs.python.org/3/whatsnew/2.1.html)).