### PR TITLE
Fix cross-platform compilation using `distutils._msvccompiler.MSVCCompiler`

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -284,7 +284,7 @@ class MSVCCompiler(CCompiler):
                 f"--plat-name must be one of {tuple(_vcvars_names)}"
             )
 
-        plat_spec = _get_vcvars_spec(get_host_platform(), get_platform())
+        plat_spec = _get_vcvars_spec(get_host_platform(), plat_name)
 
         vc_env = _get_vc_env(plat_spec)
         if not vc_env:

--- a/distutils/tests/test_msvccompiler.py
+++ b/distutils/tests/test_msvccompiler.py
@@ -43,9 +43,11 @@ class Testmsvccompiler(support.TempdirManager):
         ],
     )
     def test_cross_platform_compilation_paths(self, monkeypatch, plat_name, expected):
+        """
+        Ensure a specified target platform is passed to _get_vcvars_spec.
+        """
         compiler = _msvccompiler.MSVCCompiler()
 
-        # makes sure that the right target platform name is used
         def _get_vcvars_spec(host_platform, platform):
             assert platform == expected
 

--- a/newsfragments/298.bugfix.rst
+++ b/newsfragments/298.bugfix.rst
@@ -1,1 +1,1 @@
-Fix cross-platform compilation using `distutils._msvccompiler.MSVCCompiler` -- by :user:`saschanaz` and :user:`Avasam` 
+Fix cross-platform compilation using ``distutils._msvccompiler.MSVCCompiler`` -- by :user:`saschanaz` and :user:`Avasam` 

--- a/newsfragments/298.bugfix.rst
+++ b/newsfragments/298.bugfix.rst
@@ -1,0 +1,1 @@
+Fix cross-platform compilation using `distutils._msvccompiler.MSVCCompiler` -- by :user:`saschanaz` and :user:`Avasam` 


### PR DESCRIPTION
Actually use the `plat_name` param in `MSVCCompiler.initialize`
Thanks @saschanaz https://github.com/pypa/distutils/pull/285#discussion_r1759843926

Fixes https://github.com/pypa/setuptools/issues/4648#issuecomment-2351176463