### PR TITLE
Use minimum requirement for jaraco.functools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.8"
 dependencies = [
 	# Setuptools must require these
 	"packaging",
-	"jaraco.functools",
+	"jaraco.functools >= 4",
 	"more_itertools",
 	"jaraco.collections",
 ]


### PR DESCRIPTION
Adds a minimum requirement to jaraco.functools

Closes https://github.com/pypa/distutils/issues/300