### PR TITLE
Use a real boolean (False) default for display_option_names generated attributes

### DIFF
--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -139,7 +139,7 @@ Common commands: (see '--help-commands' for more)
         self.dry_run = False
         self.help = False
         for attr in self.display_option_names:
-            setattr(self, attr, 0)
+            setattr(self, attr, False)
 
         # Store the distribution meta-data (name, version, author, and so
         # forth) in a separate object -- we're getting to have enough


### PR DESCRIPTION
Not sure if this deserves a changelog entry, its mainly for static type-checking to remove `Literal[0]` jank like https://github.com/python/typeshed/blob/559ae9730ba3dab1305cdbaf2c29786ff38d740d/stubs/setuptools/setuptools/_distutils/dist.pyi#L155-L175

Relates to https://github.com/pypa/setuptools/pull/4691 as well