### PR TITLE
Make reinitialize_command's return type Generic when "command" argument is a Command

### DIFF
--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -4,14 +4,19 @@ Provides the Command class, the base class for the command classes
 in the distutils.command package.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import re
 import sys
+from typing import TypeVar, overload
 
 from . import _modified, archive_util, dir_util, file_util, util
 from ._log import log
 from .errors import DistutilsOptionError
+
+_CommandT = TypeVar("_CommandT", bound="Command")
 
 
 class Command:
@@ -305,7 +310,17 @@ class Command:
 
     # XXX rename to 'get_reinitialized_command()'? (should do the
     # same in dist.py, if so)
-    def reinitialize_command(self, command, reinit_subcommands=False):
+    @overload
+    def reinitialize_command(
+        self, command: str, reinit_subcommands: bool = False
+    ) -> Command: ...
+    @overload
+    def reinitialize_command(
+        self, command: _CommandT, reinit_subcommands: bool = False
+    ) -> _CommandT: ...
+    def reinitialize_command(
+        self, command: str | Command, reinit_subcommands=False
+    ) -> Command:
         return self.distribution.reinitialize_command(command, reinit_subcommands)
 
     def run_command(self, command):

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -4,6 +4,8 @@ Provides the Distribution class, which represents the module distribution
 being built/installed/distributed.
 """
 
+from __future__ import annotations
+
 import contextlib
 import logging
 import os
@@ -13,6 +15,7 @@ import sys
 import warnings
 from collections.abc import Iterable
 from email import message_from_file
+from typing import TYPE_CHECKING, TypeVar, overload
 
 from packaging.utils import canonicalize_name, canonicalize_version
 
@@ -26,6 +29,11 @@ from .errors import (
 )
 from .fancy_getopt import FancyGetopt, translate_longopt
 from .util import check_environ, rfc822_escape, strtobool
+
+if TYPE_CHECKING:
+    from .cmd import Command
+
+_CommandT = TypeVar("_CommandT", bound="Command")
 
 # Regex to define acceptable Distutils command names.  This is not *quite*
 # the same as a Python NAME -- I don't allow leading underscores.  The fact
@@ -900,7 +908,17 @@ Common commands: (see '--help-commands' for more)
             except ValueError as msg:
                 raise DistutilsOptionError(msg)
 
-    def reinitialize_command(self, command, reinit_subcommands=False):
+    @overload
+    def reinitialize_command(
+        self, command: str, reinit_subcommands: bool = False
+    ) -> Command: ...
+    @overload
+    def reinitialize_command(
+        self, command: _CommandT, reinit_subcommands: bool = False
+    ) -> _CommandT: ...
+    def reinitialize_command(
+        self, command: str | Command, reinit_subcommands=False
+    ) -> Command:
         """Reinitializes a command to the state it was in when first
         returned by 'get_command_obj()': ie., initialized but not yet
         finalized.  This provides the opportunity to sneak option


### PR DESCRIPTION
This is a part of adding typeshed's typevars to setuptools, but this change is better handled on distutils' side rather than adding typing-only overloaded overrides in setuptools.

This won't have any effect outside this repo and https://github.com/pypa/setuptools/pull/4704 until https://github.com/pypa/setuptools/issues/4689 , but it also shouldn't have any negative effect by itself.