### PR TITLE
Set `Py_GIL_DISABLED=1` for free threaded Python on Windows

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -23,7 +23,7 @@ from ..errors import (
 )
 from ..extension import Extension
 from ..sysconfig import customize_compiler, get_config_h_filename, get_python_version
-from ..util import get_platform, is_mingw
+from ..util import get_platform, is_mingw, is_freethreaded
 
 # An extension name is just a dot-separated list of Python NAMEs (ie.
 # the same as a fully-qualified module name).
@@ -332,6 +332,12 @@ class build_ext(Command):
         # late initialization of compiler even if they shouldn't...)
         if os.name == 'nt' and self.plat_name != get_platform():
             self.compiler.initialize(self.plat_name)
+
+        # The official Windows free threaded Python installer doesn't set
+        # Py_GIL_DISABLED because its pyconfig.h is shared with the
+        # default build, so we need to define it here.
+        if os.name == 'nt' and is_freethreaded():
+            self.compiler.define_macro('Py_GIL_DISABLED', '1')
 
         # And make sure that any compile/link-related options (which might
         # come from the command-line or from the setup script) are set in

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -335,7 +335,8 @@ class build_ext(Command):
 
         # The official Windows free threaded Python installer doesn't set
         # Py_GIL_DISABLED because its pyconfig.h is shared with the
-        # default build, so we need to define it here.
+        # default build, so we need to define it here
+        # (see pypa/setuptools#4662).
         if os.name == 'nt' and is_freethreaded():
             self.compiler.define_macro('Py_GIL_DISABLED', '1')
 

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -503,3 +503,7 @@ def is_mingw():
     get_platform() starts with 'mingw'.
     """
     return sys.platform == 'win32' and get_platform().startswith('mingw')
+
+def is_freethreaded():
+    """Return True if the Python interpreter is built with free threading support."""
+    return bool(sysconfig.get_config_var('Py_GIL_DISABLED'))


### PR DESCRIPTION
When free threaded CPython is installed from the official Windows installer it doesn't have the macro `Py_GIL_DISABLED` properly set becuase its `pyconfig.h` file is shared across the co-installed default build.

Define the macro when building free threaded Python extensions on Windows so that each individual C API extension doesn't have to work around this limitation.

See https://github.com/pypa/setuptools/issues/4662