### PR TITLE
Accept any non-string iterable for `distutils.Extension`'s sources

### DIFF
--- a/distutils/extension.py
+++ b/distutils/extension.py
@@ -115,7 +115,7 @@ class Extension:
                 "'sources' must be an iterable of strings or PathLike objects, not a string"
             )
 
-        # mow we check if it's iterable and contains valid types
+        # now we check if it's iterable and contains valid types
         try:
             self.sources = list(map(os.fspath, sources))
         except TypeError:

--- a/distutils/extension.py
+++ b/distutils/extension.py
@@ -117,18 +117,13 @@ class Extension:
 
         # mow we check if it's iterable and contains valid types
         try:
-            sources = list(sources)  # convert to list for consistency
-            if not all(isinstance(v, (str, os.PathLike)) for v in sources):
-                raise AssertionError(
-                    "All elements in 'sources' must be strings or PathLike objects"
-                )
+            self.sources = list(map(os.fspath, sources))
         except TypeError:
             raise AssertionError(
                 "'sources' must be an iterable of strings or PathLike objects"
             )
 
         self.name = name
-        self.sources = list(map(os.fspath, sources))
         self.include_dirs = include_dirs or []
         self.define_macros = define_macros or []
         self.undef_macros = undef_macros or []

--- a/distutils/extension.py
+++ b/distutils/extension.py
@@ -109,7 +109,7 @@ class Extension:
         if not isinstance(name, str):
             raise AssertionError("'name' must be a string")  # noqa: TRY004
 
-        # we handle the string case first; though strings are iterable, we disallow them
+        # handle the string case first; since strings are iterable, disallow them
         if isinstance(sources, str):
             raise AssertionError(  # noqa: TRY004
                 "'sources' must be an iterable of strings or PathLike objects, not a string"

--- a/distutils/extension.py
+++ b/distutils/extension.py
@@ -107,11 +107,11 @@ class Extension:
         **kw,  # To catch unknown keywords
     ):
         if not isinstance(name, str):
-            raise AssertionError("'name' must be a string")  # noqa: TRY004
+            raise TypeError("'name' must be a string")  # noqa: TRY004
 
         # handle the string case first; since strings are iterable, disallow them
         if isinstance(sources, str):
-            raise AssertionError(  # noqa: TRY004
+            raise TypeError(
                 "'sources' must be an iterable of strings or PathLike objects, not a string"
             )
 
@@ -119,7 +119,7 @@ class Extension:
         try:
             self.sources = list(map(os.fspath, sources))
         except TypeError:
-            raise AssertionError(
+            raise TypeError(
                 "'sources' must be an iterable of strings or PathLike objects"
             )
 

--- a/distutils/tests/test_extension.py
+++ b/distutils/tests/test_extension.py
@@ -63,16 +63,16 @@ class TestExtension:
 
     def test_extension_init(self):
         # the first argument, which is the name, must be a string
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             Extension(1, [])
         ext = Extension('name', [])
         assert ext.name == 'name'
 
         # the second argument, which is the list of files, must
         # be an iterable of strings or PathLike objects, and not a string
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             Extension('name', 'file')
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             Extension('name', ['file', 1])
         ext = Extension('name', ['file1', 'file2'])
         assert ext.sources == ['file1', 'file2']

--- a/distutils/tests/test_extension.py
+++ b/distutils/tests/test_extension.py
@@ -69,7 +69,7 @@ class TestExtension:
         assert ext.name == 'name'
 
         # the second argument, which is the list of files, must
-        # be a list of strings or PathLike objects, and not a string
+        # be an iterable of strings or PathLike objects, and not a string
         with pytest.raises(AssertionError):
             Extension('name', 'file')
         with pytest.raises(AssertionError):

--- a/distutils/tests/test_extension.py
+++ b/distutils/tests/test_extension.py
@@ -69,7 +69,7 @@ class TestExtension:
         assert ext.name == 'name'
 
         # the second argument, which is the list of files, must
-        # be a list of strings or PathLike objects
+        # be a list of strings or PathLike objects, and not a string
         with pytest.raises(AssertionError):
             Extension('name', 'file')
         with pytest.raises(AssertionError):
@@ -77,6 +77,16 @@ class TestExtension:
         ext = Extension('name', ['file1', 'file2'])
         assert ext.sources == ['file1', 'file2']
         ext = Extension('name', [pathlib.Path('file1'), pathlib.Path('file2')])
+        assert ext.sources == ['file1', 'file2']
+
+        # any non-string iterable of strings or PathLike objects should work
+        ext = Extension('name', ('file1', 'file2'))  # tuple
+        assert ext.sources == ['file1', 'file2']
+        ext = Extension('name', {'file1', 'file2'})  # set
+        assert sorted(ext.sources) == ['file1', 'file2']
+        ext = Extension('name', iter(['file1', 'file2']))  # iterator
+        assert ext.sources == ['file1', 'file2']
+        ext = Extension('name', [pathlib.Path('file1'), 'file2'])  # mixed types
         assert ext.sources == ['file1', 'file2']
 
         # others arguments have defaults


### PR DESCRIPTION
## Description

This PR continues what was discussed in https://github.com/python/typeshed/pull/12958#issuecomment-2460661585 on allowing a loosened check for the source files for a `distutils` `Extension` instance.

Previously: just lists were accepted; now: any non-string iterable is accepted (tuples, sets, other iterators, etc.). I plan to update python/typeshed in accordance with this change.

## Additional context

xref: https://github.com/python/mypy/issues/18107, https://github.com/python/typeshed/pull/12958