### PR TITLE
fix ldcxxshared contains ccache

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -290,7 +290,7 @@ def _customize_macos():
 
 def _cleanup_ccache(s: str) -> str:
     split = shlex.split(s)
-    if split[0] in {'ccache', 'sccache'}:
+    if split[0].endswith(('ccache', 'sccache')):
         return shlex.join(split[1:])
     return s
 

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -15,6 +15,7 @@ import pathlib
 import re
 import sys
 import sysconfig
+import shlex
 
 from jaraco.functools import pass_none
 
@@ -333,6 +334,9 @@ def customize_compiler(compiler):
         cxx = os.environ.get('CXX', cxx)
         ldshared = os.environ.get('LDSHARED', ldshared)
         ldcxxshared = os.environ.get('LDCXXSHARED', ldcxxshared)
+        __ldcxxshared_split = shlex.split(ldcxxshared)
+        if __ldcxxshared_split[0] in {'ccache', 'sccache'}:
+            ldcxxshared = shlex.join(__ldcxxshared_split[1:])
         cpp = os.environ.get(
             'CPP',
             cc + " -E",  # not always

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -288,6 +288,12 @@ def _customize_macos():
         get_config_vars()
     )
 
+def _cleanup_ccache(s: str) -> str:
+    split = shlex.split(s)
+    if split[0] in {'ccache', 'sccache'}:
+        return shlex.join(split[1:])
+    return s
+
 
 def customize_compiler(compiler):
     """Do any platform-specific customization of a CCompiler instance.
@@ -332,11 +338,8 @@ def customize_compiler(compiler):
                 ldshared = newcc + ldshared[len(cc) :]
             cc = newcc
         cxx = os.environ.get('CXX', cxx)
-        ldshared = os.environ.get('LDSHARED', ldshared)
-        ldcxxshared = os.environ.get('LDCXXSHARED', ldcxxshared)
-        __ldcxxshared_split = shlex.split(ldcxxshared)
-        if __ldcxxshared_split[0] in {'ccache', 'sccache'}:
-            ldcxxshared = shlex.join(__ldcxxshared_split[1:])
+        ldshared = os.environ.get('LDSHARED', _cleanup_ccache(ldshared))
+        ldcxxshared = os.environ.get('LDCXXSHARED', _cleanup_ccache(ldcxxshared))
         cpp = os.environ.get(
             'CPP',
             cc + " -E",  # not always


### PR DESCRIPTION
## Summary of changes

LDCXXSHARED will be `"ccache /usr/bin/c++ -shared"` if it's compiled with ccache, and it will fail linker

I'm not sure how to test this...

<!-- Summary goes here -->

Closes https://github.com/pypa/setuptools/issues/4748
