### PR TITLE
Run Ruff 0.8.0 (automated fixes only)

### DIFF
--- a/distutils/command/build_clib.py
+++ b/distutils/command/build_clib.py
@@ -138,8 +138,7 @@ class build_clib(Command):
 
             if '/' in name or (os.sep != '/' and os.sep in name):
                 raise DistutilsSetupError(
-                    f"bad library name '{lib[0]}': "
-                    "may not contain directory separators"
+                    f"bad library name '{lib[0]}': may not contain directory separators"
                 )
 
             if not isinstance(build_info, dict):

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -443,8 +443,7 @@ class build_ext(Command):
                 for macro in macros:
                     if not (isinstance(macro, tuple) and len(macro) in (1, 2)):
                         raise DistutilsSetupError(
-                            "'macros' element of build info dict "
-                            "must be 1- or 2-tuple"
+                            "'macros' element of build info dict must be 1- or 2-tuple"
                         )
                     if len(macro) == 1:
                         ext.undef_macros.append(macro[0])
@@ -672,8 +671,7 @@ class build_ext(Command):
                 return "swig.exe"
         else:
             raise DistutilsPlatformError(
-                "I don't know how to find (much less run) SWIG "
-                f"on platform '{os.name}'"
+                f"I don't know how to find (much less run) SWIG on platform '{os.name}'"
             )
 
     # -- Name generators -----------------------------------------------

--- a/distutils/command/check.py
+++ b/distutils/command/check.py
@@ -46,10 +46,7 @@ class check(Command):
         (
             'restructuredtext',
             'r',
-            (
-                'Checks if long string meta-data syntax '
-                'are reStructuredText-compliant'
-            ),
+            'Checks if long string meta-data syntax are reStructuredText-compliant',
         ),
         ('strict', 's', 'Will exit with an error if a check fails'),
     ]

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import functools
 import os
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..core import Command
 from ..util import change_root, convert_path
@@ -22,8 +22,7 @@ class install_data(Command):
         (
             'install-dir=',
             'd',
-            "base directory for installing data files "
-            "[default: installation base dir]",
+            "base directory for installing data files [default: installation base dir]",
         ),
         ('root=', None, "install everything relative to this alternate root directory"),
         ('force', 'f', "force installation (overwrite existing files)"),

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -12,7 +12,8 @@ import getopt
 import re
 import string
 import sys
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from .errors import DistutilsArgError, DistutilsGetoptError
 
@@ -167,8 +168,7 @@ class FancyGetopt:
 
             if not ((short is None) or (isinstance(short, str) and len(short) == 1)):
                 raise DistutilsGetoptError(
-                    f"invalid short option '{short}': "
-                    "must a single character or None"
+                    f"invalid short option '{short}': must a single character or None"
                 )
 
             self.repeat[long] = repeat

--- a/distutils/filelist.py
+++ b/distutils/filelist.py
@@ -127,10 +127,7 @@ class FileList:
             for pattern in patterns:
                 if not self.exclude_pattern(pattern, anchor=True):
                     log.warning(
-                        (
-                            "warning: no previously-included files "
-                            "found matching '%s'"
-                        ),
+                        "warning: no previously-included files found matching '%s'",
                         pattern,
                     )
 

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 import sys
 import warnings
-from typing import Mapping
+from collections.abc import Mapping
 
 from ._log import log
 from .debug import DEBUG

--- a/distutils/tests/__init__.py
+++ b/distutils/tests/__init__.py
@@ -8,7 +8,7 @@ by import rather than matching pre-defined names.
 """
 
 import shutil
-from typing import Sequence
+from collections.abc import Sequence
 
 
 def missing_compiler_executable(cmd_names: Sequence[str] = []):  # pragma: no cover

--- a/distutils/tests/test_file_util.py
+++ b/distutils/tests/test_file_util.py
@@ -44,18 +44,19 @@ class TestFileUtil:
 
     def test_move_file_exception_unpacking_rename(self):
         # see issue 22182
-        with mock.patch("os.rename", side_effect=OSError("wrong", 1)), pytest.raises(
-            DistutilsFileError
+        with (
+            mock.patch("os.rename", side_effect=OSError("wrong", 1)),
+            pytest.raises(DistutilsFileError),
         ):
             jaraco.path.build({self.source: 'spam eggs'})
             move_file(self.source, self.target, verbose=False)
 
     def test_move_file_exception_unpacking_unlink(self):
         # see issue 22182
-        with mock.patch(
-            "os.rename", side_effect=OSError(errno.EXDEV, "wrong")
-        ), mock.patch("os.unlink", side_effect=OSError("wrong", 1)), pytest.raises(
-            DistutilsFileError
+        with (
+            mock.patch("os.rename", side_effect=OSError(errno.EXDEV, "wrong")),
+            mock.patch("os.unlink", side_effect=OSError("wrong", 1)),
+            pytest.raises(DistutilsFileError),
         ):
             jaraco.path.build({self.source: 'spam eggs'})
             move_file(self.source, self.target, verbose=False)

--- a/distutils/tests/test_spawn.py
+++ b/distutils/tests/test_spawn.py
@@ -73,9 +73,12 @@ class TestSpawn(support.TempdirManager):
         # PATH='': no match, except in the current directory
         with os_helper.EnvironmentVarGuard() as env:
             env['PATH'] = ''
-            with mock.patch(
-                'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
-            ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
+            with (
+                mock.patch(
+                    'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
+                ),
+                mock.patch('distutils.spawn.os.defpath', tmp_dir),
+            ):
                 rv = find_executable(program)
                 assert rv is None
 
@@ -87,9 +90,10 @@ class TestSpawn(support.TempdirManager):
         # PATH=':': explicitly looks in the current directory
         with os_helper.EnvironmentVarGuard() as env:
             env['PATH'] = os.pathsep
-            with mock.patch(
-                'distutils.spawn.os.confstr', return_value='', create=True
-            ), mock.patch('distutils.spawn.os.defpath', ''):
+            with (
+                mock.patch('distutils.spawn.os.confstr', return_value='', create=True),
+                mock.patch('distutils.spawn.os.defpath', ''),
+            ):
                 rv = find_executable(program)
                 assert rv is None
 
@@ -103,16 +107,22 @@ class TestSpawn(support.TempdirManager):
             env.pop('PATH', None)
 
             # without confstr
-            with mock.patch(
-                'distutils.spawn.os.confstr', side_effect=ValueError, create=True
-            ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
+            with (
+                mock.patch(
+                    'distutils.spawn.os.confstr', side_effect=ValueError, create=True
+                ),
+                mock.patch('distutils.spawn.os.defpath', tmp_dir),
+            ):
                 rv = find_executable(program)
                 assert rv == filename
 
             # with confstr
-            with mock.patch(
-                'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
-            ), mock.patch('distutils.spawn.os.defpath', ''):
+            with (
+                mock.patch(
+                    'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
+                ),
+                mock.patch('distutils.spawn.os.defpath', ''),
+            ):
                 rv = find_executable(program)
                 assert rv == filename
 

--- a/distutils/tests/test_unixccompiler.py
+++ b/distutils/tests/test_unixccompiler.py
@@ -272,13 +272,12 @@ class TestUnixCCompiler(support.TempdirManager):
 
         sysconfig.get_config_var = gcv
         sysconfig.get_config_vars = gcvs
-        with mock.patch.object(
-            self.cc, 'spawn', return_value=None
-        ) as mock_spawn, mock.patch.object(
-            self.cc, '_need_link', return_value=True
-        ), mock.patch.object(
-            self.cc, 'mkpath', return_value=None
-        ), EnvironmentVarGuard() as env:
+        with (
+            mock.patch.object(self.cc, 'spawn', return_value=None) as mock_spawn,
+            mock.patch.object(self.cc, '_need_link', return_value=True),
+            mock.patch.object(self.cc, 'mkpath', return_value=None),
+            EnvironmentVarGuard() as env,
+        ):
             env['CC'] = 'ccache my_cc'
             env['CXX'] = 'my_cxx'
             del env['LDSHARED']

--- a/distutils/tests/test_version.py
+++ b/distutils/tests/test_version.py
@@ -53,9 +53,9 @@ class TestVersion:
             res = StrictVersion(v1)._cmp(v2)
             assert res == wanted, f'cmp({v1}, {v2}) should be {wanted}, got {res}'
             res = StrictVersion(v1)._cmp(object())
-            assert (
-                res is NotImplemented
-            ), f'cmp({v1}, {v2}) should be NotImplemented, got {res}'
+            assert res is NotImplemented, (
+                f'cmp({v1}, {v2}) should be NotImplemented, got {res}'
+            )
 
     def test_cmp(self):
         versions = (
@@ -75,6 +75,6 @@ class TestVersion:
             res = LooseVersion(v1)._cmp(v2)
             assert res == wanted, f'cmp({v1}, {v2}) should be {wanted}, got {res}'
             res = LooseVersion(v1)._cmp(object())
-            assert (
-                res is NotImplemented
-            ), f'cmp({v1}, {v2}) should be NotImplemented, got {res}'
+            assert res is NotImplemented, (
+                f'cmp({v1}, {v2}) should be NotImplemented, got {res}'
+            )

--- a/distutils/version.py
+++ b/distutils/version.py
@@ -53,8 +53,7 @@ class Version:
         if vstring:
             self.parse(vstring)
         warnings.warn(
-            "distutils Version classes are deprecated. "
-            "Use packaging.version instead.",
+            "distutils Version classes are deprecated. Use packaging.version instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,6 +19,10 @@ extend-select = [
 	"YTT",
 ]
 ignore = [
+	# TODO: Fix these new violations in Ruff 0.8.0
+	"UP031",
+	"UP036",
+
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",
 	"E111",


### PR DESCRIPTION
I ran `ruff check --fix` then `ruff format` then added `"UP031", "UP036",` to `ruff.lint.ignore` (to be completed in a separate PR, I'm keeping automated changes here)

Python 3.8 code path removal (`UP036`) is done in https://github.com/pypa/distutils/pull/315
Manual fixes for `%` formatted strings are done in https://github.com/pypa/distutils/pull/317