### PR TITLE
Fix test_mkpath_exception_uncached

### DIFF
--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -106,8 +106,9 @@ class TestDirUtil(support.TempdirManager):
         """
         An exception in listdir should raise a DistutilsFileError
         """
-        with mock.patch("os.listdir", side_effect=OSError()), pytest.raises(
-            errors.DistutilsFileError
+        with (
+            mock.patch("os.listdir", side_effect=OSError()),
+            pytest.raises(errors.DistutilsFileError),
         ):
             src = self.tempdirs[-1]
             dir_util.copy_tree(src, None)

--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -3,6 +3,7 @@
 import os
 import pathlib
 import stat
+import sys
 import unittest.mock as mock
 from distutils import dir_util, errors
 from distutils.dir_util import (
@@ -124,9 +125,12 @@ class TestDirUtil(support.TempdirManager):
             def mkdir(self, *args, **kwargs):
                 raise OSError("Failed to create directory")
 
-            _flavour = (
-                pathlib._windows_flavour if os.name == 'nt' else pathlib._posix_flavour
-            )
+            if sys.version_info < (3, 12):
+                _flavour = (
+                    pathlib._windows_flavour
+                    if os.name == 'nt'
+                    else pathlib._posix_flavour
+                )
 
         target = tmp_path / 'foodir'
 

--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -124,7 +124,7 @@ class TestDirUtil(support.TempdirManager):
             def mkdir(self, *args, **kwargs):
                 raise OSError("Failed to create directory")
 
-            _flavor = (
+            _flavour = (
                 pathlib._windows_flavour if os.name == 'nt' else pathlib._posix_flavour
             )
 

--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -123,6 +123,10 @@ class TestDirUtil(support.TempdirManager):
             def mkdir(self, *args, **kwargs):
                 raise OSError("Failed to create directory")
 
+            _flavor = (
+                pathlib._windows_flavour if os.name == 'nt' else pathlib._posix_flavour
+            )
+
         target = tmp_path / 'foodir'
 
         with pytest.raises(errors.DistutilsFileError):

--- a/distutils/tests/test_dir_util.py
+++ b/distutils/tests/test_dir_util.py
@@ -126,11 +126,7 @@ class TestDirUtil(support.TempdirManager):
                 raise OSError("Failed to create directory")
 
             if sys.version_info < (3, 12):
-                _flavour = (
-                    pathlib._windows_flavour
-                    if os.name == 'nt'
-                    else pathlib._posix_flavour
-                )
+                _flavour = pathlib.Path()._flavour
 
         target = tmp_path / 'foodir'
 


### PR DESCRIPTION
Attempt (because Ruff failures right now make this hard to confirm in isolation) at fixing the following test failure https://github.com/pypa/distutils/actions/runs/11999395994/job/33447255455?pr=314#step:5:187
```py
__________________ TestDirUtil.test_mkpath_exception_uncached __________________

self = <distutils.tests.test_dir_util.TestDirUtil object at 0x7f66ff36a490>
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7f66ff180850>
tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_mkpath_exception_uncached0')

    def test_mkpath_exception_uncached(self, monkeypatch, tmp_path):
        """
        Caching should not remember failed attempts.
    
        pypa/distutils#304
        """
    
        class FailPath(pathlib.Path):
            def mkdir(self, *args, **kwargs):
                raise OSError("Failed to create directory")
    
        target = tmp_path / 'foodir'
    
        with pytest.raises(errors.DistutilsFileError):
>           mkpath(FailPath(target))

distutils/tests/test_dir_util.py:130: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/pathlib.py:871: in __new__
    self = cls._from_parts(args)
/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/pathlib.py:509: in _from_parts
    drv, root, parts = self._parse_args(args)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'distutils.tests.test_dir_util.TestDirUtil.test_mkpath_exception_uncached.<locals>.FailPath'>
args = (PosixPath('/tmp/pytest-of-runner/pytest-0/test_mkpath_exception_uncached0/foodir'),)

    @classmethod
    def _parse_args(cls, args):
        # This is useful when you don't want to create an instance, just
        # canonicalize some constructor arguments.
        parts = []
        for a in args:
            if isinstance(a, PurePath):
                parts += a._parts
            else:
                a = os.fspath(a)
                if isinstance(a, str):
                    # Force-cast str subclasses to str (issue #21127)
                    parts.append(str(a))
                else:
                    raise TypeError(
                        "argument should be a str object or an os.PathLike "
                        "object returning str, not %r"
                        % type(a))
>       return cls._flavour.parse_parts(parts)
E       AttributeError: type object 'FailPath' has no attribute '_flavour'
```

The issue is that when instanciated, a `Path` checks whether it's an exact instance of `Path` before deferring its `self/cls` to `WindowsPath` or `PosixPath`, which do implement the `_flavor` attribute. But since `FailPath` is a subclass of `Path`, the overriding of `cls` never happens.