### PR TITLE
Type `Command.sub_commands` to avoid variance issues

### DIFF
--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -10,7 +10,8 @@ import logging
 import os
 import re
 import sys
-from typing import TypeVar, overload
+from collections.abc import Callable
+from typing import Any, ClassVar, TypeVar, overload
 
 from . import _modified, archive_util, dir_util, file_util, util
 from ._log import log
@@ -49,7 +50,9 @@ class Command:
     # 'sub_commands' is usually defined at the *end* of a class, because
     # predicates can be unbound methods, so they must already have been
     # defined.  The canonical example is the "install" command.
-    sub_commands = []
+    sub_commands: ClassVar[  # Any to work around variance issues
+        list[tuple[str, Callable[[Any], bool] | None]]
+    ] = []
 
     # -- Creation/initialization methods -------------------------------
 


### PR DESCRIPTION
This mirrors https://github.com/python/typeshed/pull/11951 and solves an issue revealed by https://github.com/pypa/setuptools/pull/4704