### PR TITLE
Coerce Distribution.script_args to list

### DIFF
--- a/distutils/core.py
+++ b/distutils/core.py
@@ -6,9 +6,12 @@ indirectly provides the Distribution and Command classes, although they are
 really defined in distutils.dist and distutils.cmd.
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import tokenize
+from collections.abc import Iterable
 
 from .cmd import Command
 from .debug import DEBUG
@@ -215,7 +218,7 @@ def run_commands(dist):
     return dist
 
 
-def run_setup(script_name, script_args=None, stop_after="run"):
+def run_setup(script_name, script_args: Iterable[str] | None = None, stop_after="run"):
     """Run a setup script in a somewhat controlled environment, and
     return the Distribution instance that drives things.  This is useful
     if you need to find out the distribution meta-data (passed as

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -169,7 +169,7 @@ Common commands: (see '--help-commands' for more)
         # and sys.argv[1:], but they can be overridden when the caller is
         # not necessarily a setup script run from the command-line.
         self.script_name = None
-        self.script_args = None
+        self.script_args: list[str] | None = None
 
         # 'command_options' is where we store command options between
         # parsing them (from config files, the command-line, etc.) and when
@@ -269,6 +269,8 @@ Common commands: (see '--help-commands' for more)
         self.want_user_cfg = True
 
         if self.script_args is not None:
+            # Coerce any possible iterable from attrs into a list
+            self.script_args = list(self.script_args)
             for arg in self.script_args:
                 if not arg.startswith('-'):
                     break

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -8,6 +8,8 @@ additional features:
   * options set attributes of a passed-in object
 """
 
+from __future__ import annotations
+
 import getopt
 import re
 import string
@@ -219,7 +221,7 @@ class FancyGetopt:
                 self.short_opts.append(short)
                 self.short2long[short[0]] = long
 
-    def getopt(self, args=None, object=None):  # noqa: C901
+    def getopt(self, args: Sequence[str] | None = None, object=None):  # noqa: C901
         """Parse command-line options in args. Store as attributes on object.
 
         If 'args' is None or not supplied, uses 'sys.argv[1:]'.  If
@@ -375,7 +377,7 @@ class FancyGetopt:
             file.write(line + "\n")
 
 
-def fancy_getopt(options, negative_opt, object, args):
+def fancy_getopt(options, negative_opt, object, args: Sequence[str] | None):
     parser = FancyGetopt(options)
     parser.set_negative_aliases(negative_opt)
     return parser.getopt(args, object)

--- a/distutils/tests/test_dist.py
+++ b/distutils/tests/test_dist.py
@@ -246,6 +246,12 @@ class TestDistributionBehavior(support.TempdirManager):
         # make sure --no-user-cfg disables the user cfg file
         assert len(all_files) - 1 == len(files)
 
+    def test_script_args_list_coercion(self):
+        d = Distribution(attrs={'script_args': ('build', '--no-user-cfg')})
+
+        # make sure script_args is a list even if it started as a different iterable
+        assert d.script_args == ['build', '--no-user-cfg']
+
     @pytest.mark.skipif(
         'platform.system() == "Windows"',
         reason='Windows does not honor chmod 000',


### PR DESCRIPTION
This will allow any iterable to be passed as `script_args` for `setup`.
After this is merged, typeshed can be updated to reflect this change, which will allow https://github.com/jaraco/jaraco.office/pull/2/files#diff-bb91dce3f1ce94166001a97817fed8d6a6a56c6d7f95233cc28268aea7f05778R24 to pass.

If you don't want the coercion, then `script_args` should at least be typed as `Sequence[str]` and https://github.com/python/typeshed/pull/13116 should be merged first.

I also noticed, I think there's no validation that `script_args` isn't a plain `str`