### PR TITLE
Use CFLAGS if set as-is, match CXXFLAGS behavior

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -340,6 +340,7 @@ def customize_compiler(compiler):
 
         ldshared = _add_flags(ldshared, 'LD')
         ldcxxshared = _add_flags(ldcxxshared, 'LD')
+        cflags = os.environ.get('CFLAGS', cflags)
         cflags = _add_flags(cflags, 'C')
         ldshared = _add_flags(ldshared, 'C')
         cxxflags = os.environ.get('CXXFLAGS', cxxflags)

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -130,7 +130,9 @@ class TestSysconfig:
         comp = self.customize_compiler()
         assert comp.exes['archiver'] == 'env_ar --env-arflags'
         assert comp.exes['preprocessor'] == 'env_cpp --env-cppflags'
-        assert comp.exes['compiler'] == 'env_cc --env-cflags --env-cflags --env-cppflags'
+        assert (
+            comp.exes['compiler'] == 'env_cc --env-cflags --env-cflags --env-cppflags'
+        )
         assert comp.exes['compiler_so'] == (
             'env_cc --env-cflags --env-cflags --env-cppflags --sc-ccshared'
         )

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -130,9 +130,9 @@ class TestSysconfig:
         comp = self.customize_compiler()
         assert comp.exes['archiver'] == 'env_ar --env-arflags'
         assert comp.exes['preprocessor'] == 'env_cpp --env-cppflags'
-        assert comp.exes['compiler'] == 'env_cc --sc-cflags --env-cflags --env-cppflags'
+        assert comp.exes['compiler'] == 'env_cc --env-cflags --env-cflags --env-cppflags'
         assert comp.exes['compiler_so'] == (
-            'env_cc --sc-cflags --env-cflags --env-cppflags --sc-ccshared'
+            'env_cc --env-cflags --env-cflags --env-cppflags --sc-ccshared'
         )
         assert (
             comp.exes['compiler_cxx']


### PR DESCRIPTION
Since 2c937116cc0dcd9b26b6070e89a3dc5dcbedc2ae, CXXFLAGS is used as-is if set in the envionment rather than clobbered by whatever CPython happened to be built with.

Do the same for CFLAGS: use it as-is if set in the environment, don't prepend CPython's saved flags.

Fixes: https://github.com/pypa/distutils/issues/299