### PR TITLE
Don't duplicate CFLAGS

### DIFF
--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -341,7 +341,6 @@ def customize_compiler(compiler):
         ldshared = _add_flags(ldshared, 'LD')
         ldcxxshared = _add_flags(ldcxxshared, 'LD')
         cflags = os.environ.get('CFLAGS', cflags)
-        cflags = _add_flags(cflags, 'C')
         ldshared = _add_flags(ldshared, 'C')
         cxxflags = os.environ.get('CXXFLAGS', cxxflags)
         ldcxxshared = _add_flags(ldcxxshared, 'CXX')

--- a/distutils/tests/test_sysconfig.py
+++ b/distutils/tests/test_sysconfig.py
@@ -130,11 +130,9 @@ class TestSysconfig:
         comp = self.customize_compiler()
         assert comp.exes['archiver'] == 'env_ar --env-arflags'
         assert comp.exes['preprocessor'] == 'env_cpp --env-cppflags'
-        assert (
-            comp.exes['compiler'] == 'env_cc --env-cflags --env-cflags --env-cppflags'
-        )
+        assert comp.exes['compiler'] == 'env_cc --env-cflags --env-cppflags'
         assert comp.exes['compiler_so'] == (
-            'env_cc --env-cflags --env-cflags --env-cppflags --sc-ccshared'
+            'env_cc --env-cflags --env-cppflags --sc-ccshared'
         )
         assert (
             comp.exes['compiler_cxx']


### PR DESCRIPTION
Followup to af7fcbb0d56ae14753db53acd8792eddb4d8f814. I accidentally left that in when trying two approaches.

Reported at https://github.com/pypa/distutils/pull/322#discussion_r1898349462.