### PR TITLE
Export `PyInit_pkg` for `pkg.__init__` instead of `PyInit___init__`

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -729,7 +729,7 @@ class build_ext(Command):
         provided, "PyInit_" + module_name.  Only relevant on Windows, where
         the .pyd file (DLL) must export the module "PyInit_" function.
         """
-        name = ext.name.split('.')[-1]
+        name = self._get_module_name_for_symbol(ext)
         try:
             # Unicode module name support as defined in PEP-489
             # https://peps.python.org/pep-0489/#export-hook-name
@@ -743,6 +743,15 @@ class build_ext(Command):
         if initfunc_name not in ext.export_symbols:
             ext.export_symbols.append(initfunc_name)
         return ext.export_symbols
+
+    def _get_module_name_for_symbol(self, ext):
+        # Package name should be used for `__init__` modules
+        # https://github.com/python/cpython/issues/80074
+        # https://github.com/pypa/setuptools/issues/4826
+        parts = ext.name.split(".")
+        if parts[-1] == "__init__" and len(parts) >= 2:
+            return parts[-2]
+        return parts[-1]
 
     def get_libraries(self, ext):  # noqa: C901
         """Return the list of libraries to link against when building a

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -345,6 +345,19 @@ class TestBuildExt(TempdirManager):
         assert cmd.get_export_symbols(modules[0]) == ['PyInit_foo']
         assert cmd.get_export_symbols(modules[1]) == ['PyInitU_f_1gaa']
 
+    def test_export_symbols__init__(self):
+        # https://github.com/python/cpython/issues/80074
+        # https://github.com/pypa/setuptools/issues/4826
+        modules = [
+            Extension('foo.__init__', ['aaa']),
+            Extension('föö.__init__', ['uuu']),
+        ]
+        dist = Distribution({'name': 'xx', 'ext_modules': modules})
+        cmd = self.build_ext(dist)
+        cmd.ensure_finalized()
+        assert cmd.get_export_symbols(modules[0]) == ['PyInit_foo']
+        assert cmd.get_export_symbols(modules[1]) == ['PyInitU_f_1gaa']
+
     def test_compiler_option(self):
         # cmd.compiler is an option and
         # should not be overridden by a compiler instance


### PR DESCRIPTION
This is a possible solution for https://github.com/pypa/setuptools/issues/4826, using an approach similar to the one suggested in https://github.com/python/cpython/issues/80074#issuecomment-1093812266.

The comment https://github.com/pypa/setuptools/issues/4826#issuecomment-2660168154 seems to indicate this approach would work.

@jaraco, the discussion in https://github.com/python/cpython/issues/80074 suggests the change to be implemented in `pypa/setuptools`, but I feel that it is much cleaner if we do it in `pypa/distutils` (otherwise we would have to copy+paste the entirety of the existing `distutils.command.build_ext:build_ext.get_export_symbols` code).

Given the fact that using `stdlib`'s `distutils` is now deprecated and that this is an edge case, I guess it should be fine...
Please let me know if you would like to do something different.