### PR TITLE
Fix failing Ruff test

### DIFF
--- a/distutils/compilers/C/tests/test_base.py
+++ b/distutils/compilers/C/tests/test_base.py
@@ -15,7 +15,7 @@ def _make_strs(paths):
     """
     Convert paths to strings for legacy compatibility.
     """
-    if sys.version_info > (3, 8) and platform.system() != "Windows":
+    if sys.version_info >= (3, 8) and platform.system() != "Windows":
         return paths
     return list(map(os.fspath, paths))
 


### PR DESCRIPTION
There's a warning-based test that also fails, idk about that.
It's also on Python 3.10 so I'm pretty confident it doesn't have to do with these changes.