### PR TITLE
In build_scripts, unconditionally set shebang to #!python.

### DIFF
--- a/distutils/command/build_scripts.py
+++ b/distutils/command/build_scripts.py
@@ -75,7 +75,7 @@ class build_scripts(Command):
 
         return outfiles, updated_files
 
-    def _copy_script(self, script, outfiles, updated_files):  # noqa: C901
+    def _copy_script(self, script, outfiles, updated_files):
         shebang_match = None
         script = convert_path(script)
         outfile = os.path.join(self.build_dir, os.path.basename(script))

--- a/distutils/command/build_scripts.py
+++ b/distutils/command/build_scripts.py
@@ -5,7 +5,6 @@ Implements the Distutils 'build_scripts' command."""
 import os
 import re
 import tokenize
-from distutils import sysconfig
 from distutils._log import log
 from stat import ST_MODE
 from typing import ClassVar
@@ -106,18 +105,8 @@ class build_scripts(Command):
         if shebang_match:
             log.info("copying and adjusting %s -> %s", script, self.build_dir)
             if not self.dry_run:
-                if not sysconfig.python_build:
-                    executable = self.executable
-                else:
-                    executable = os.path.join(
-                        sysconfig.get_config_var("BINDIR"),
-                        "python{}{}".format(
-                            sysconfig.get_config_var("VERSION"),
-                            sysconfig.get_config_var("EXE"),
-                        ),
-                    )
                 post_interp = shebang_match.group(1) or ''
-                shebang = "#!" + executable + post_interp + "\n"
+                shebang = f"#!python{post_interp}\n"
                 self._validate_shebang(shebang, f.encoding)
                 with open(outfile, "w", encoding=f.encoding) as outf:
                     outf.write(shebang)


### PR DESCRIPTION
In the past, distutils then Setuptools was a (/the) primary installer for packages. It therefore took on the responsibility of rewriting Python shebangs in scripts.

Later, Setuptools became primarily a build backend and defers to installers (pip, uv, ...) to do the rewriting. Yet, the rewrite logic remained in Setuptools and leads to complications (see astral-sh/uv#2744).

This change removes that rewriting logic, replacing it with a static `#!python` shebang to be rewritten by the installers.

I note that the test suite continues to pass unchanged, so the legacy behavior is not captured in the tests. Furthermore, I don't personally install explicit scripts in any of my packages (as they tend to be non-portable). We'll need to find another way to validate the impact of this change.

Closes pypa/setuptools#4863.