### PR TITLE
Restore public symbols missing after compilers move

### DIFF
--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -1,3 +1,5 @@
 from .compilers.C import msvc
 
+__all__ = ["MSVCCompiler"]
+
 MSVCCompiler = msvc.Compiler

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -1,17 +1,18 @@
 from .compilers.C import base
 from .compilers.C.base import (
-    CompileError,
-    LinkError,
+    compiler_class,
     gen_lib_options,
     gen_preprocess_options,
     get_default_compiler,
     new_compiler,
     show_compilers,
 )
+from .compilers.C.errors import CompileError, LinkError
 
 __all__ = [
     'CompileError',
     'LinkError',
+    'compiler_class',
     'gen_lib_options',
     'gen_preprocess_options',
     'get_default_compiler',

--- a/newsfragments/4876.bugfix.rst
+++ b/newsfragments/4876.bugfix.rst
@@ -1,0 +1,1 @@
+Restore `distutils.ccompiler.compiler_class` -- by :user:`Avasam`


### PR DESCRIPTION
Closes https://github.com/pypa/distutils/issues/336 and closes https://github.com/pypa/setuptools/issues/4876

- Adds back `distutils.ccompiler.compiler_class` for backwards compatibility
- Removes importing the `msvc` symbol when `from distutils._msvccompiler import *`