### PR TITLE
Remove/replace runtime dependence on `more-itertools`, `jaraco.functools`, and `jaraco.collections`

### DIFF
--- a/distutils/_modified.py
+++ b/distutils/_modified.py
@@ -7,8 +7,6 @@ import os.path
 from collections.abc import Callable, Iterable
 from typing import Literal, TypeVar
 
-from jaraco.functools import splat
-
 from .compat.py39 import zip_strict
 from .errors import DistutilsFileError
 
@@ -57,7 +55,11 @@ def newer_pairwise(
     targets) where source is newer than target, according to the semantics
     of 'newer()'.
     """
-    newer_pairs = filter(splat(newer), zip_strict(sources, targets))
+    newer_pairs = [
+        (source, target)
+        for source, target in zip_strict(sources, targets)
+        if newer(source, target)
+    ]
     return tuple(map(list, zip(*newer_pairs))) or ([], [])
 
 

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -4,6 +4,7 @@ Implements the Distutils 'install' command."""
 
 from __future__ import annotations
 
+import collections
 import contextlib
 import itertools
 import os
@@ -12,8 +13,6 @@ import sysconfig
 from distutils._log import log
 from site import USER_BASE, USER_SITE
 from typing import ClassVar
-
-import jaraco.collections
 
 from ..core import Command
 from ..debug import DEBUG
@@ -432,12 +431,12 @@ class install(Command):
             local_vars['userbase'] = self.install_userbase
             local_vars['usersite'] = self.install_usersite
 
-        self.config_vars = jaraco.collections.DictStack([
-            fw.vars(),
-            compat_vars,
-            sysconfig.get_config_vars(),
+        self.config_vars = collections.ChainMap(
             local_vars,
-        ])
+            sysconfig.get_config_vars(),
+            compat_vars,
+            fw.vars(),
+        )
 
         self.expand_basedirs()
 

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -20,8 +20,6 @@ from typing import (
     overload,
 )
 
-from more_itertools import always_iterable
-
 from ..._log import log
 from ..._modified import newer_group
 from ...dir_util import mkpath
@@ -1368,7 +1366,11 @@ def gen_lib_options(
     lib_opts = [compiler.library_dir_option(dir) for dir in library_dirs]
 
     for dir in runtime_library_dirs:
-        lib_opts.extend(always_iterable(compiler.runtime_library_dir_option(dir)))
+        opt = compiler.runtime_library_dir_option(dir)
+        if isinstance(opt, str):
+            lib_opts.append(opt)
+        else:
+            lib_opts.extend(opt)
 
     # XXX it's important that we *not* remove redundant library mentions!
     # sometimes you really do have to say "-lfoo -lbar -lfoo" in order to

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -19,8 +19,6 @@ import sys
 import sysconfig
 from typing import TYPE_CHECKING, Literal, overload
 
-from jaraco.functools import pass_none
-
 from .ccompiler import CCompiler
 from .compat import py39
 from .errors import DistutilsPlatformError
@@ -77,8 +75,9 @@ def _is_parent(dir_a, dir_b):
 
 if os.name == 'nt':
 
-    @pass_none
     def _fix_pcbuild(d):
+        if d is None:
+            return None
         # In a venv, sys._home will be inside BASE_PREFIX rather than PREFIX.
         prefixes = PREFIX, BASE_PREFIX
         matched = (
@@ -147,12 +146,11 @@ def get_python_inc(plat_specific: bool = False, prefix: str | None = None) -> st
     return getter(resolved_prefix, prefix, plat_specific)
 
 
-@pass_none
 def _extant(path):
     """
     Replace path with None if it doesn't exist.
     """
-    return path if os.path.exists(path) else None
+    return (path if os.path.exists(path) else None) if (path is not None) else None
 
 
 def _get_python_inc_posix(prefix, spec_prefix, plat_specific):
@@ -597,12 +595,17 @@ def get_config_var(name: str) -> int | str | None:
     return get_config_vars().get(name)
 
 
-@pass_none
-def _add_flags(value: str, type: str) -> str:
+@overload
+def _add_flags(value: None, type: str) -> None: ...
+@overload
+def _add_flags(value: str, type: str) -> str: ...
+def _add_flags(value: str | None, type: str) -> str | None:
     """
     Add any flags from the environment for the given type.
 
     type is the prefix to FLAGS in the environment key (e.g. "C" for "CFLAGS").
     """
+    if value is None:
+        return None
     flags = os.environ.get(f'{type}FLAGS')
     return f'{value} {flags}' if flags else value

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -150,7 +150,7 @@ def _extant(path):
     """
     Replace path with None if it doesn't exist.
     """
-    return (path if os.path.exists(path) else None) if (path is not None) else None
+    return path if path is not None and os.path.exists(path) else None
 
 
 def _get_python_inc_posix(prefix, spec_prefix, plat_specific):

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -17,9 +17,7 @@ import sys
 import sysconfig
 import tempfile
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, AnyStr
-
-from jaraco.functools import pass_none
+from typing import TYPE_CHECKING, AnyStr, overload
 
 from ._log import log
 from ._modified import newer
@@ -120,8 +118,11 @@ def split_version(s: str) -> list[int]:
     return [int(n) for n in s.split('.')]
 
 
-@pass_none
-def convert_path(pathname: str | os.PathLike[str]) -> str:
+@overload
+def convert_path(pathname: None) -> None: ...
+@overload
+def convert_path(pathname: str | os.PathLike[str]) -> str: ...
+def convert_path(pathname: str | os.PathLike[str] | None) -> str | None:
     r"""
     Allow for pathlib.Path inputs, coax to a native path string.
 
@@ -136,6 +137,8 @@ def convert_path(pathname: str | os.PathLike[str]) -> str:
     >>> convert_path('foo/./bar').replace('\\', '/')
     'foo/bar'
     """
+    if pathname is None:
+        return None
     return os.fspath(pathlib.PurePath(pathname))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,6 @@ requires-python = ">=3.9"
 dependencies = [
 	# Setuptools must require these
 	"packaging",
-	"jaraco.functools >= 4",
-	"more_itertools",
-	"jaraco.collections",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
A very small diff that would remove 3/4 of distutil's current dependencies.

Imo, this makes distutils easier to understand by replacing opaque helpers with a) well-known stdlib alternatives, or b) obvious and short idiomatic Python. It also should make vendoring distutils easier (e.g. what setuptools does).

(Re. tests: I ran them locally on Windows via tox, and the results before and after were the same — everything passed besides 1 unrelated cygwin thing.)

(I can make an issue about this first if need be — the diff is so small that I figured this wouldn't hurt, though.)
