### PR TITLE
Make sure `type(None)` is used instead of `None` for the type argument of `isinstance`.

### DIFF
--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -237,7 +237,7 @@ class Compiler:
         """
         A valid macro is a ``name : str`` and a ``value : str | None``.
         """
-        return isinstance(name, str) and isinstance(value, (str, None))
+        return isinstance(name, str) and isinstance(value, (str, type(None)))
 
     # -- Bookkeeping methods -------------------------------------------
 

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -236,6 +236,9 @@ class Compiler:
     def _is_valid_macro(name, value=None):
         """
         A valid macro is a ``name : str`` and a ``value : str | None``.
+
+        >>> Compiler._is_valid_macro('foo', None)
+        True
         """
         return isinstance(name, str) and isinstance(value, (str, type(None)))
 


### PR DESCRIPTION
Using None, whether alone or in a tuple, as the second argument of isinstance(...) raises a TypeError at runtime. It's not a valid type.