### PR TITLE
Remove Python 3.7 code paths

### DIFF
--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -145,7 +145,7 @@ def _resolve_scheme(name):
     try:
         resolved = sysconfig.get_preferred_scheme(key)
     except Exception:
-        resolved = fw.scheme(_pypy_hack(name))
+        resolved = fw.scheme(name)
     return resolved
 
 
@@ -162,7 +162,7 @@ def _inject_headers(name, scheme):
     """
     # Bypass the preferred scheme, which may not
     # have defined headers.
-    fallback = _load_scheme(_pypy_hack(name))
+    fallback = _load_scheme(name)
     scheme.setdefault('headers', fallback['headers'])
     return scheme
 
@@ -170,14 +170,6 @@ def _inject_headers(name, scheme):
 def _scheme_attrs(scheme):
     """Resolve install directories by applying the install schemes."""
     return {f'install_{key}': scheme[key] for key in SCHEME_KEYS}
-
-
-def _pypy_hack(name):
-    PY37 = sys.version_info < (3, 8)
-    old_pypy = hasattr(sys, 'pypy_version_info') and PY37
-    prefix = not name.endswith(('_user', '_home'))
-    pypy_name = 'pypy' + '_nt' * (os.name == 'nt')
-    return pypy_name if old_pypy and prefix else name
 
 
 class install(Command):

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -156,8 +156,6 @@ def _extant(path):
 
 
 def _get_python_inc_posix(prefix, spec_prefix, plat_specific):
-    if IS_PYPY and sys.version_info < (3, 8):
-        return os.path.join(prefix, 'include')
     return (
         _get_python_inc_posix_python(plat_specific)
         or _extant(_get_python_inc_from_config(plat_specific, spec_prefix))
@@ -245,14 +243,6 @@ def get_python_lib(
     If 'prefix' is supplied, use it instead of sys.base_prefix or
     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
     """
-
-    if IS_PYPY and sys.version_info < (3, 8):
-        # PyPy-specific schema
-        if prefix is None:
-            prefix = PREFIX
-        if standard_lib:
-            return os.path.join(prefix, "lib-python", sys.version_info.major)
-        return os.path.join(prefix, 'site-packages')
 
     early_prefix = prefix
 


### PR DESCRIPTION
Split from https://github.com/pypa/distutils/pull/343
I added a feature request to Ruff (https://github.com/astral-sh/ruff/issues/16487) to catch those on top of [outdated-version-block (UP036)](https://docs.astral.sh/ruff/rules/outdated-version-block/#outdated-version-block-up036)

This shouldn't be a user visible change since this was unreachable code.