### PR TITLE
Re-enable mypy with only simple fixes

### DIFF
--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -120,12 +120,12 @@ class Compiler:
     }
     language_order: ClassVar[list[str]] = ["c++", "objc", "c"]
 
-    include_dirs = []
+    include_dirs: list[str] = []
     """
     include dirs specific to this compiler class
     """
 
-    library_dirs = []
+    library_dirs: list[str] = []
     """
     library dirs specific to this compiler class
     """
@@ -148,14 +148,14 @@ class Compiler:
         self.macros: list[_Macro] = []
 
         # 'include_dirs': a list of directories to search for include files
-        self.include_dirs: list[str] = []
+        self.include_dirs = []
 
         # 'libraries': a list of libraries to include in any link
         # (library names, not filenames: eg. "foo" not "libfoo.a")
         self.libraries: list[str] = []
 
         # 'library_dirs': a list of directories to search for libraries
-        self.library_dirs: list[str] = []
+        self.library_dirs = []
 
         # 'runtime_library_dirs': a list of directories to search for
         # shared libraries/objects at runtime

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -323,7 +323,7 @@ class Compiler(base.Compiler):
         compiler = os.path.basename(shlex.split(cc_var)[0])
         return "gcc" in compiler or "g++" in compiler
 
-    def runtime_library_dir_option(self, dir: str) -> str | list[str]:
+    def runtime_library_dir_option(self, dir: str) -> str | list[str]:  # type: ignore[override] # Fixed in pypa/distutils#339
         # XXX Hackish, at the very least.  See Python bug #445902:
         # https://bugs.python.org/issue445902
         # Linkers on different platforms need different options to

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -183,7 +183,7 @@ Common commands: (see '--help-commands' for more)
         # can 1) quickly figure out which class to instantiate when
         # we need to create a new command object, and 2) have a way
         # for the setup script to override command classes
-        self.cmdclass = {}
+        self.cmdclass: dict[str, type[Command]] = {}
 
         # 'command_packages' is a list of packages in which commands
         # are searched for.  The factory for command 'foo' is expected
@@ -1168,6 +1168,7 @@ class DistributionMetadata:
             value = msg[name]
             if value and value != "UNKNOWN":
                 return value
+            return None
 
         def _read_list(name):
             values = msg.get_all(name, None)

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -146,7 +146,7 @@ class TestBuildExt(TempdirManager):
 
     @staticmethod
     def _test_xx(copy_so):
-        import xx
+        import xx  # type: ignore[import-not-found] # Module generated for tests
 
         for attr in ('error', 'foo', 'new', 'roj'):
             assert hasattr(xx, attr)

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,44 @@ explicit_package_bases = True
 disable_error_code =
 	# Disable due to many false positives
 	overload-overlap,
+
+# local
+
+	# TODO: Resolve and re-enable these gradually
+	operator,
+	attr-defined,
+	arg-type,
+	assignment,
+	call-overload,
+	return-value,
+	index,
+	type-var,
+	func-returns-value,
+	union-attr,
+	str-bytes-safe,
+	misc,
+	has-type,
+
+# Is only imported in a test and doesn't seem relevant.
+# TODO: Should we add types-pygments or remove from the test?
+[mypy-pygments.*]
+ignore_missing_imports = True
+
+# stdlib's test module is not typed on typeshed
+[mypy-test.*]
+ignore_missing_imports = True
+
+# https://github.com/jaraco/jaraco.envs/issues/7
+# https://github.com/jaraco/jaraco.envs/pull/8
+[mypy-jaraco.envs.*]
+ignore_missing_imports = True
+
+# https://github.com/jaraco/jaraco.path/issues/2
+# https://github.com/jaraco/jaraco.path/pull/7
+[mypy-jaraco.path.*]
+ignore_missing_imports = True
+
+# https://github.com/jaraco/jaraco.text/issues/17
+# https://github.com/jaraco/jaraco.text/pull/23
+[mypy-jaraco.text.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,8 @@ type = [
 	"pytest-mypy",
 
 	# local
+	"types-docutils",
 ]
 
 
 [tool.setuptools_scm]
-
-
-[tool.pytest-enabler.mypy]
-# Disabled due to jaraco/skeleton#143
-# Disabled as distutils isn't ready yet


### PR DESCRIPTION
Re-enable mypy tests with a bunch of codes disabled.

This is a subset of https://github.com/pypa/distutils/pull/343 with only very simple non-runtime fixes

Relates to https://github.com/jaraco/skeleton/issues/98