### PR TITLE
Only import modules in `distutils/command/__init__.py` if type checking

### DIFF
--- a/distutils/command/__init__.py
+++ b/distutils/command/__init__.py
@@ -3,24 +3,27 @@
 Package containing implementation of all the standard Distutils
 commands."""
 
-from . import (
-    bdist,
-    bdist_dumb,
-    bdist_rpm,
-    build,
-    build_clib,
-    build_ext,
-    build_py,
-    build_scripts,
-    check,
-    clean,
-    install,
-    install_data,
-    install_headers,
-    install_lib,
-    install_scripts,
-    sdist,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import (
+        bdist,
+        bdist_dumb,
+        bdist_rpm,
+        build,
+        build_clib,
+        build_ext,
+        build_py,
+        build_scripts,
+        check,
+        clean,
+        install,
+        install_data,
+        install_headers,
+        install_lib,
+        install_scripts,
+        sdist,
+    )
 
 __all__ = [
     'bdist',


### PR DESCRIPTION
Fix #351
`Fix` pypa/setuptools#4902
`Fix` pypa/setuptools#4906
`Fix` pypa/setuptools#4908

Uses the approach described in https://github.com/pypa/distutils/pull/345#issuecomment-2741454564