### PR TITLE
Always return an actual `bool` from ``has_*`` functions

### DIFF
--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -136,16 +136,16 @@ class build(Command):
 
     # -- Predicates for the sub-command list ---------------------------
 
-    def has_pure_modules(self):
+    def has_pure_modules(self) -> bool:
         return self.distribution.has_pure_modules()
 
-    def has_c_libraries(self):
+    def has_c_libraries(self) -> bool:
         return self.distribution.has_c_libraries()
 
-    def has_ext_modules(self):
+    def has_ext_modules(self) -> bool:
         return self.distribution.has_ext_modules()
 
-    def has_scripts(self):
+    def has_scripts(self) -> bool:
         return self.distribution.has_scripts()
 
     sub_commands = [

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -772,24 +772,24 @@ class install(Command):
 
     # -- Predicates for sub-command list -------------------------------
 
-    def has_lib(self):
+    def has_lib(self) -> bool:
         """Returns true if the current distribution has any Python
         modules to install."""
         return (
             self.distribution.has_pure_modules() or self.distribution.has_ext_modules()
         )
 
-    def has_headers(self):
+    def has_headers(self) -> bool:
         """Returns true if the current distribution has any headers to
         install."""
         return self.distribution.has_headers()
 
-    def has_scripts(self):
+    def has_scripts(self) -> bool:
         """Returns true if the current distribution has any scripts to.
         install."""
         return self.distribution.has_scripts()
 
-    def has_data(self):
+    def has_data(self) -> bool:
         """Returns true if the current distribution has any data to.
         install."""
         return self.distribution.has_data_files()

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -6,6 +6,8 @@ the Mingw32CCompiler class which handles the mingw32 port of GCC (same as
 cygwin in no-cygwin mode).
 """
 
+from __future__ import annotations
+
 import copy
 import os
 import pathlib
@@ -327,7 +329,7 @@ def check_config_h():
         return code, f"{fn!r} {mention_inflected} {substring!r}"
 
 
-def is_cygwincc(cc):
+def is_cygwincc(cc: str | shlex._ShlexInstream) -> bool:
     """Try to determine if the compiler that would be used is from cygwin."""
     out_string = check_output(shlex.split(cc) + ['-dumpmachine'])
     return out_string.strip().endswith(b'cygwin')

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -1024,25 +1024,25 @@ Common commands: (see '--help-commands' for more)
     # -- Distribution query methods ------------------------------------
 
     def has_pure_modules(self) -> bool:
-        return len(self.packages or self.py_modules or []) > 0
+        return bool(self.packages or self.py_modules)
 
     def has_ext_modules(self) -> bool:
-        return bool(self.ext_modules and len(self.ext_modules) > 0)
+        return bool(self.ext_modules)
 
     def has_c_libraries(self) -> bool:
-        return bool(self.libraries and len(self.libraries) > 0)
+        return bool(self.libraries)
 
     def has_modules(self) -> bool:
         return self.has_pure_modules() or self.has_ext_modules()
 
     def has_headers(self) -> bool:
-        return bool(self.headers and len(self.headers) > 0)
+        return bool(self.headers)
 
     def has_scripts(self) -> bool:
-        return bool(self.scripts and len(self.scripts) > 0)
+        return bool(self.scripts)
 
     def has_data_files(self) -> bool:
-        return bool(self.data_files and len(self.data_files) > 0)
+        return bool(self.data_files)
 
     def is_pure(self) -> bool:
         return (

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -1027,22 +1027,22 @@ Common commands: (see '--help-commands' for more)
         return len(self.packages or self.py_modules or []) > 0
 
     def has_ext_modules(self) -> bool:
-        return self.ext_modules and len(self.ext_modules) > 0
+        return bool(self.ext_modules and len(self.ext_modules) > 0)
 
     def has_c_libraries(self) -> bool:
-        return self.libraries and len(self.libraries) > 0
+        return bool(self.libraries and len(self.libraries) > 0)
 
     def has_modules(self) -> bool:
         return self.has_pure_modules() or self.has_ext_modules()
 
     def has_headers(self) -> bool:
-        return self.headers and len(self.headers) > 0
+        return bool(self.headers and len(self.headers) > 0)
 
     def has_scripts(self) -> bool:
-        return self.scripts and len(self.scripts) > 0
+        return bool(self.scripts and len(self.scripts) > 0)
 
     def has_data_files(self) -> bool:
-        return self.data_files and len(self.data_files) > 0
+        return bool(self.data_files and len(self.data_files) > 0)
 
     def is_pure(self) -> bool:
         return (

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -105,7 +105,7 @@ class FancyGetopt:
             self.option_table.append(option)
             self.option_index[long_option] = option
 
-    def has_option(self, long_option):
+    def has_option(self, long_option: str) -> bool:
         """Return true if the option table for this parser has an
         option with long name 'long_option'."""
         return long_option in self.option_index

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -513,6 +513,6 @@ def is_mingw() -> bool:
     return sys.platform == 'win32' and get_platform().startswith('mingw')
 
 
-def is_freethreaded():
+def is_freethreaded() -> bool:
     """Return True if the Python interpreter is built with free threading support."""
     return bool(sysconfig.get_config_var('Py_GIL_DISABLED'))


### PR DESCRIPTION
Reduce changes from #343

Technically a user-facing change, but not sure how to present that in a changelog for setuptools, considering the changelog entry "Always return an actual `bool` from ``has_*`` functions" wouldn't apply to all setuptools' own methods.