### PR TITLE
Make `test_check` consistent on test environment

### DIFF
--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -8,12 +8,6 @@ from distutils.tests import support
 
 import pytest
 
-try:
-    import pygments
-except ImportError:
-    pygments = None
-
-
 HERE = os.path.dirname(__file__)
 
 
@@ -103,7 +97,6 @@ class TestCheck(support.TempdirManager):
             assert cmd._warnings == 0
 
     def test_check_document(self):
-        pytest.importorskip('docutils')
         pkg_info, dist = self.create_dist()
         cmd = check(dist)
 
@@ -118,7 +111,6 @@ class TestCheck(support.TempdirManager):
         assert len(msgs) == 0
 
     def test_check_restructuredtext(self):
-        pytest.importorskip('docutils')
         # let's see if it detects broken rest in long_description
         broken_rest = 'title\n===\n\ntest'
         pkg_info, dist = self.create_dist(long_description=broken_rest)
@@ -149,9 +141,7 @@ class TestCheck(support.TempdirManager):
         assert cmd._warnings == 0
 
     def test_check_restructuredtext_with_syntax_highlight(self):
-        pytest.importorskip('docutils')
         # Don't fail if there is a `code` or `code-block` directive
-
         example_rst_docs = [
             textwrap.dedent(
                 """\
@@ -179,15 +169,9 @@ class TestCheck(support.TempdirManager):
             pkg_info, dist = self.create_dist(long_description=rest_with_code)
             cmd = check(dist)
             cmd.check_restructuredtext()
+            assert cmd._warnings == 0
             msgs = cmd._check_rst_data(rest_with_code)
-            if pygments is not None:
-                assert len(msgs) == 0
-            else:
-                assert len(msgs) == 1
-                assert (
-                    str(msgs[0][1])
-                    == 'Cannot analyze code. Pygments package not found.'
-                )
+            assert len(msgs) == 0
 
     def test_check_all(self):
         with pytest.raises(DistutilsSetupError):

--- a/mypy.ini
+++ b/mypy.ini
@@ -31,11 +31,6 @@ disable_error_code =
 	misc,
 	has-type,
 
-# Is only imported in a test and doesn't seem relevant.
-# TODO: Should we add types-pygments or remove from the test?
-[mypy-pygments.*]
-ignore_missing_imports = True
-
 # stdlib's test module is not typed on typeshed
 [mypy-test.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,13 @@ test = [
 	"pytest >= 6, != 8.1.*",
 
 	# local
-	"pytest >= 7.4.3", # 186
+	"pytest >= 7.4.3", # pypa/distutils#186
 	"jaraco.envs>=2.4",
 	"jaraco.path",
 	"jaraco.text",
 	"path >= 10.6",
 	"docutils",
+	"Pygments",
 	"pyfakefs",
 	"more_itertools",
 


### PR DESCRIPTION
Reduces changes from #343

With tox and `project.optional-dependencies.test`, dependencies are ensured to be available.

Reverts workarounds from https://github.com/pypa/distutils/commit/06e8590eef402ebcb2a179875572549b5fe8d946 and https://github.com/pypa/distutils/commit/3789d73e316092bc2b65960f3fa8706bc0afa3c3