### PR TITLE
Respect CXX when parsing linker parameters for UNIX c++ targets

### DIFF
--- a/distutils/compilers/C/tests/test_unix.py
+++ b/distutils/compilers/C/tests/test_unix.py
@@ -245,6 +245,60 @@ class TestUnixCCompiler(support.TempdirManager):
         assert self.cc.linker_so[0] == 'my_cc'
 
     @pytest.mark.skipif('platform.system == "Windows"')
+    def test_cxx_commands_used_are_correct(self):
+        def gcv(v):
+            if v == 'LDSHARED':
+                return 'ccache gcc-4.2 -bundle -undefined dynamic_lookup'
+            elif v == 'LDCXXSHARED':
+                return 'ccache g++-4.2 -bundle -undefined dynamic_lookup'
+            elif v == 'CXX':
+                return 'ccache g++-4.2'
+            elif v == 'CC':
+                return 'ccache gcc-4.2'
+            return ''
+
+        def gcvs(*args, _orig=sysconfig.get_config_vars):
+            if args:
+                return list(map(sysconfig.get_config_var, args))
+            return _orig()
+
+        sysconfig.get_config_var = gcv
+        sysconfig.get_config_vars = gcvs
+        with (
+            mock.patch.object(self.cc, 'spawn', return_value=None) as mock_spawn,
+            mock.patch.object(self.cc, '_need_link', return_value=True),
+            mock.patch.object(self.cc, 'mkpath', return_value=None),
+            EnvironmentVarGuard() as env,
+        ):
+            sysconfig.customize_compiler(self.cc)
+            assert self.cc.linker_so_cxx[0:2] == ['ccache', 'g++-4.2']
+            assert self.cc.linker_exe_cxx[0:2] == ['ccache', 'g++-4.2']
+            self.cc.link(None, [], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['ccache', 'g++-4.2', '-bundle', '-undefined', 'dynamic_lookup']
+            assert call_args[:5] == expected
+
+            self.cc.link_executable([], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['ccache', 'g++-4.2', '-o', 'a.out']
+            assert call_args[:4] == expected
+
+            env['LDCXXSHARED'] = 'wrapper g++-4.2 -bundle -undefined dynamic_lookup'
+            env['CXX'] = 'wrapper g++-4.2'
+            sysconfig.customize_compiler(self.cc)
+            assert self.cc.linker_so_cxx[0:2] == ['wrapper', 'g++-4.2']
+            assert self.cc.linker_exe_cxx[0:2] == ['wrapper', 'g++-4.2']
+            self.cc.link(None, [], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['wrapper', 'g++-4.2', '-bundle', '-undefined', 'dynamic_lookup']
+            assert call_args[:5] == expected
+
+            self.cc.link_executable([], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['wrapper', 'g++-4.2', '-o', 'a.out']
+            assert call_args[:4] == expected
+
+    @pytest.mark.skipif('platform.system == "Windows"')
     @pytest.mark.usefixtures('disable_macos_customization')
     def test_cc_overrides_ldshared_for_cxx_correctly(self):
         """

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -286,19 +286,18 @@ class Compiler(base.Compiler):
                 # building an executable or linker_so (with shared options)
                 # when building a shared library.
                 building_exe = target_desc == base.Compiler.EXECUTABLE
+                target_cxx = target_lang == "c++"
                 linker = (
-                    self.linker_exe
+                    (self.linker_exe_cxx if target_cxx else self.linker_exe)
                     if building_exe
-                    else (
-                        self.linker_so_cxx if target_lang == "c++" else self.linker_so
-                    )
+                    else (self.linker_so_cxx if target_cxx else self.linker_so)
                 )[:]
 
-                if target_lang == "c++" and self.compiler_cxx:
+                if target_cxx and self.compiler_cxx:
                     env, linker_ne = _split_env(linker)
                     aix, linker_na = _split_aix(linker_ne)
                     _, compiler_cxx_ne = _split_env(self.compiler_cxx)
-                    _, linker_exe_ne = _split_env(self.linker_exe)
+                    _, linker_exe_ne = _split_env(self.linker_exe_cxx)
 
                     params = _linker_params(linker_na, linker_exe_ne)
                     linker = env + aix + compiler_cxx_ne + params


### PR DESCRIPTION
Previously, when parsing linker parameters for C++ targets, the CC
variable was used to determine what the "prefix" of the command was in
order to determine what the linker arguments were.

If the value of LDCXXSHARED did not match CC, the first argument would
be dropped as it was assumed to be the linker command.

However, if the command was a wrapper, such as ccache, it could lead to
compile problems as the generated command would be incorrect.

In the following scenario:
  LDCXXSHARED="ccache g++ -shared -Wl,--enable-new-dtags"
  CC="ccache gcc"
  CXX="ccache g++"

The command would be incorrectly parsed to:
  "ccache g++ g++ -shared -Wl,--enable-new-dtags"

Now, the CXX value is used to improve the chances of parsing the linker
arguments correctly to generate:
  "ccache g++ -shared -Wl,--enable-new-dtags"

LDCXXSHARED and CXX still need to be in sync either in the environment
or within the sysconfig variables in the CPython build for parsing to
work correctly.

The CXX value is now also respected when linking executable binaries.

closes #355 