### PR TITLE
Better coverage in test_check

### DIFF
--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -193,14 +193,13 @@ class TestCheck(support.TempdirManager):
 
     @pytest.mark.parametrize('descr', code_examples)
     def test_check_rst_with_syntax_highlight_pygments(self, descr):
-        msgs = self.check_rst_data(descr)
-        assert len(msgs) == 0
+        assert self.check_rst_data(descr) == []
 
     @pytest.mark.parametrize('descr', code_examples)
     def test_check_rst_with_syntax_highlight_no_pygments(self, descr, hide_pygments):
-        msgs = self.check_rst_data(descr)
-        assert len(msgs) == 1
-        assert str(msgs[0][1]) == 'Cannot analyze code. Pygments package not found.'
+        (msg,) = self.check_rst_data(descr)
+        _, exc, _, _ = msg
+        assert str(exc) == 'Cannot analyze code. Pygments package not found.'
 
     def test_check_all(self):
         with pytest.raises(DistutilsSetupError):

--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -165,8 +165,6 @@ class TestCheck(support.TempdirManager):
         ],
     )
     def test_check_restructuredtext_with_syntax_highlight(self, descr):
-        pytest.importorskip('docutils')
-
         pkg_info, dist = self.create_dist(long_description=descr)
         cmd = check(dist)
         cmd.check_restructuredtext()

--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -192,14 +192,12 @@ class TestCheck(support.TempdirManager):
         return cmd._check_rst_data(descr)
 
     @pytest.mark.parametrize('descr', code_examples)
-    def test_check_restructuredtext_with_syntax_highlight_pygments(self, descr):
+    def test_check_rst_with_syntax_highlight_pygments(self, descr):
         msgs = self.check_rst_data(descr)
         assert len(msgs) == 0
 
     @pytest.mark.parametrize('descr', code_examples)
-    def test_check_restructuredtext_with_syntax_highlight_no_pygments(
-        self, descr, hide_pygments
-    ):
+    def test_check_rst_with_syntax_highlight_no_pygments(self, descr, hide_pygments):
         msgs = self.check_rst_data(descr)
         assert len(msgs) == 1
         assert str(msgs[0][1]) == 'Cannot analyze code. Pygments package not found.'

--- a/distutils/tests/test_check.py
+++ b/distutils/tests/test_check.py
@@ -154,25 +154,16 @@ class TestCheck(support.TempdirManager):
 
         example_rst_docs = [
             textwrap.dedent(
-                """\
-            Here's some code:
+                f"""
+                Here's some code:
 
-            .. code:: python
+                .. {directive}:: python
 
-                def foo():
-                    pass
-            """
-            ),
-            textwrap.dedent(
-                """\
-            Here's some code:
-
-            .. code-block:: python
-
-                def foo():
-                    pass
-            """
-            ),
+                    def foo():
+                        pass
+                """
+            ).lstrip()
+            for directive in ['code', 'code-block']
         ]
 
         for rest_with_code in example_rst_docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
 	"docutils",
 	"pyfakefs",
 	"more_itertools",
+	"pygments",
 
 	# workaround for pytest-dev/pytest#12490
 	"pytest < 8.1; python_version < '3.12'",


### PR DESCRIPTION
Closes pypa/distutils#359 

- **Consolidate the generation of test cases.**
- **Implemented the cases as a parameterized fixture.**
- **Run the test unconditionally; it's a declared requirement.**
- **Split restructuretext tests into two to cover both cases.**
- **shorten the test names**
- **More precisely measure the expectation.**
