### PR TITLE
msvc compiler: Re-sort sources to compile Message Compiler files (`.mc`) first

### DIFF
--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -17,7 +17,7 @@ import contextlib
 import os
 import subprocess
 import tempfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import ClassVar
 
@@ -431,7 +431,7 @@ class Compiler(base.Compiler):
 
     def compile(  # noqa: C901
         self,
-        sources,
+        sources: Sequence[str | os.PathLike[str]],
         output_dir=None,
         macros=None,
         include_dirs=None,
@@ -439,9 +439,16 @@ class Compiler(base.Compiler):
         extra_preargs=None,
         extra_postargs=None,
         depends=None,
-    ):
+    ) -> list[str]:
         if not self.initialized:
             self.initialize()
+
+        # Move .mc files to the start of the list, otherwise keep the same order
+        # See pypa/setuptools#4986
+        sources = sorted(
+            sources, key=lambda source: Path(source).suffix not in self._mc_extensions
+        )
+
         compile_info = self._setup_compile(
             output_dir, macros, include_dirs, sources, depends, extra_postargs
         )

--- a/distutils/compilers/C/tests/test_msvc.py
+++ b/distutils/compilers/C/tests/test_msvc.py
@@ -2,6 +2,7 @@ import os
 import sys
 import sysconfig
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -51,6 +52,23 @@ class Testmsvccompiler:
         monkeypatch.setattr(msvc, '_get_vcvars_spec', _get_vcvars_spec)
         compiler.initialize(plat_name)
 
+    @pytest.mark.skipif(
+        not sysconfig.get_platform().startswith("win"),
+        reason="Only run test for non-mingw Windows platforms",
+    )
+    def test_sources_compilation_order(self, tmp_path: Path) -> None:
+        # We expect the the mc files to be compiled first, but otherwise keep the same order
+        test_sources = [tmp_path / file for file in ("b.cpp", "y.mc", "a.c", "z.mc")]
+        expected_objects = [
+            str(tmp_path / obj) for obj in ("y.res", "z.res", "b.obj", "a.obj")
+        ]
+        for source in test_sources:
+            source.write_text("")
+
+        compiler = msvc.Compiler()
+        objects = compiler.compile(test_sources)
+        assert objects == expected_objects
+
     @needs_winreg
     def test_get_vc_env_unicode(self):
         test_var = 'ṰḖṤṪ┅ṼẨṜ'
@@ -88,7 +106,7 @@ class CheckThread(threading.Thread):
     def run(self):
         try:
             super().run()
-        except Exception:  # noqa: BLE001 # capture any error for later inspection
+        except Exception:  # noqa BLE001 # capture any error for later inspection
             self.exc_info = sys.exc_info()
 
     def __bool__(self):


### PR DESCRIPTION
Ensures that Message Compiler files come first.

Closes https://github.com/pypa/setuptools/issues/4986

Fixes pywin32's needs for hacking a custom MSVC compiler class.