### PR TITLE
Remove unused type ignore mark

### DIFF
--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -70,7 +70,7 @@ class Compiler:
     # dictionary (see below -- used by the 'new_compiler()' factory
     # function) -- authors of new compiler interface classes are
     # responsible for updating 'compiler_class'!
-    compiler_type: ClassVar[str] = None  # type: ignore[assignment]
+    compiler_type: ClassVar[str] = None
 
     # XXX things not handled by this compiler abstraction model:
     #   * client can't provide additional options for a compiler,


### PR DESCRIPTION
In https://github.com/pypa/distutils/actions/runs/16223655098/job/45810230266?pr=373#step:6:140 (https://github.com/pypa/distutils/pull/373), there seems to be an unrelated type check error:

<img width="1248" height="556" alt="image" src="https://github.com/user-attachments/assets/2bcfc254-9f01-4c41-b123-cbd2ffb77bad" />


I believe this can be caused by an update in test dependencies (e.g. mypy 1.16.1 seems have been released in June).