### PR TITLE
Explore deprecating `create` arg of `get_command_obj` and `get_finalized_command`

### DIFF
--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -22,9 +22,14 @@ if TYPE_CHECKING:
     # type-only import because of mutual dependence between these classes
     from distutils.dist import Distribution
 
-    from typing_extensions import TypeVarTuple, Unpack
+    from typing_extensions import TypeVarTuple, Unpack, deprecated
 
     _Ts = TypeVarTuple("_Ts")
+else:
+
+    def deprecated(message):
+        return lambda fn: fn
+
 
 _StrPathT = TypeVar("_StrPathT", bound="str | os.PathLike[str]")
 _BytesPathT = TypeVar("_BytesPathT", bound="bytes | os.PathLike[bytes]")
@@ -322,11 +327,18 @@ class Command:
             if getattr(self, dst_option) is None:
                 setattr(self, dst_option, getattr(src_cmd_obj, src_option))
 
+    @overload
+    def get_finalized_command(self, command: str, create: None = None) -> Command: ...
+    @deprecated("The 'create' argument is deprecated and doesn't do anything.")
+    @overload
+    def get_finalized_command(self, command: str, create: bool) -> Command: ...
     # NOTE: Because distutils is private to Setuptools and not all commands are exposed here,
     # not every possible command is enumerated in the signature.
-    def get_finalized_command(self, command: str, create: bool = True) -> Command:
+    def get_finalized_command(
+        self, command: str, create: bool | None = None
+    ) -> Command:
         """Wrapper around Distribution's 'get_command_obj()' method: find
-        (create if necessary and 'create' is true) the command object for
+        (create if necessary) the command object for
         'command', call its 'ensure_finalized()' method, and return the
         finalized command object.
         """

--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -12,7 +12,7 @@ import re
 import sys
 from abc import abstractmethod
 from collections.abc import Callable, MutableSequence
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
 
 from . import _modified, archive_util, dir_util, file_util, util
 from ._log import log
@@ -22,9 +22,14 @@ if TYPE_CHECKING:
     # type-only import because of mutual dependence between these classes
     from distutils.dist import Distribution
 
-    from typing_extensions import TypeVarTuple, Unpack
+    from typing_extensions import TypeVarTuple, Unpack, deprecated
 
     _Ts = TypeVarTuple("_Ts")
+else:
+
+    def deprecated(message):
+        return lambda fn: fn
+
 
 _StrPathT = TypeVar("_StrPathT", bound="str | os.PathLike[str]")
 _BytesPathT = TypeVar("_BytesPathT", bound="bytes | os.PathLike[bytes]")
@@ -306,16 +311,22 @@ class Command:
             if getattr(self, dst_option) is None:
                 setattr(self, dst_option, getattr(src_cmd_obj, src_option))
 
+    @overload
+    def get_finalized_command(self, command: str, create: None = None) -> Command: ...
+    @overload
+    @deprecated("The 'create' argument is deprecated and doesn't do anything.")
+    def get_finalized_command(self, command: str, create: bool) -> Command: ...
     # NOTE: Because distutils is private to Setuptools and not all commands are exposed here,
     # not every possible command is enumerated in the signature.
-    def get_finalized_command(self, command: str, create: bool = True) -> Command:
+    def get_finalized_command(
+        self, command: str, create: bool | None = None
+    ) -> Command:
         """Wrapper around Distribution's 'get_command_obj()' method: find
-        (create if necessary and 'create' is true) the command object for
+        (create if necessary) the command object for
         'command', call its 'ensure_finalized()' method, and return the
         finalized command object.
         """
-        # TODO: Raise a more descriptive error when create=False or cmd_obj is None ?
-        cmd_obj = cast(Command, self.distribution.get_command_obj(command, create))
+        cmd_obj = self.distribution.get_command_obj(command)
         cmd_obj.ensure_finalized()
         return cmd_obj
 

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -70,7 +70,7 @@ class Compiler:
     # dictionary (see below -- used by the 'new_compiler()' factory
     # function) -- authors of new compiler interface classes are
     # responsible for updating 'compiler_class'!
-    compiler_type: ClassVar[str] = None  # type: ignore[assignment]
+    compiler_type: ClassVar[str] = None
 
     # XXX things not handled by this compiler abstraction model:
     #   * client can't provide additional options for a compiler,

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -41,11 +41,16 @@ from .util import check_environ, rfc822_escape, strtobool
 
 if TYPE_CHECKING:
     from _typeshed import SupportsWrite
-    from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias, deprecated
 
     # type-only import because of mutual dependence between these modules
     from .cmd import Command
     from .extension import Extension
+else:
+
+    def deprecated(message):
+        return lambda fn: fn
+
 
 _CommandT = TypeVar("_CommandT", bound="Command")
 _OptionsList: TypeAlias = list[
@@ -861,25 +866,27 @@ Common commands: (see '--help-commands' for more)
         raise DistutilsModuleError(f"invalid command '{command}'")
 
     @overload
-    def get_command_obj(
-        self, command: str, create: Literal[True] = True
-    ) -> Command: ...
+    def get_command_obj(self, command: str, create: None = None) -> Command: ...
+    @deprecated("The 'create' argument is deprecated and doesn't do anything.")
     @overload
-    def get_command_obj(
-        self, command: str, create: Literal[False]
-    ) -> Command | None: ...
-    def get_command_obj(self, command: str, create: bool = True) -> Command | None:
+    def get_command_obj(self, command: str, create: bool) -> Command: ...
+    def get_command_obj(self, command: str, create: object = None) -> Command | None:
         """Return the command object for 'command'.  Normally this object
         is cached on a previous call to 'get_command_obj()'; if no command
-        object for 'command' is in the cache, then we either create and
-        return it (if 'create' is true) or return None.
+        object for 'command' is in the cache, then we create and
+        return it.
         """
+        if create is not None:
+            warnings.warn(
+                "The 'create' argument is deprecated and doesn't do anything.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         cmd_obj = self.command_obj.get(command)
-        if not cmd_obj and create:
+        if not cmd_obj:
             if DEBUG:
                 self.announce(
-                    "Distribution.get_command_obj(): "
-                    f"creating '{command}' command object"
+                    f"Distribution.get_command_obj(): creating '{command}' command object"
                 )
 
             klass = self.get_command_class(command)

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -44,10 +44,16 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from _typeshed import SupportsWrite
+    from typing_extensions import deprecated
 
     # type-only import because of mutual dependence between these modules
     from .cmd import Command
     from .extension import Extension
+else:
+
+    def deprecated(message):
+        return lambda fn: fn
+
 
 _CommandT = TypeVar("_CommandT", bound="Command")
 _OptionsList: TypeAlias = list[
@@ -888,23 +894,29 @@ Common commands: (see '--help-commands' for more)
         raise DistutilsModuleError(f"invalid command '{command}'")
 
     @overload
-    def get_command_obj(
-        self, command: str, create: Literal[True] = True
-    ) -> Command: ...
+    def get_command_obj(self, command: str, create: None = None) -> Command: ...
     @overload
-    def get_command_obj(self, command: str, create: bool) -> Command | None: ...
-    def get_command_obj(self, command: str, create: bool = True) -> Command | None:
+    @deprecated("The 'create' argument is deprecated and doesn't do anything.")
+    def get_command_obj(self, command: str, create: bool) -> Command: ...
+    def get_command_obj(
+        self, command: str, create: bool | None = None
+    ) -> Command | None:
         """Return the command object for 'command'.  Normally this object
         is cached on a previous call to 'get_command_obj()'; if no command
-        object for 'command' is in the cache, then we either create and
-        return it (if 'create' is true) or return None.
+        object for 'command' is in the cache, then we create and
+        return it.
         """
+        if create is not None:
+            warnings.warn(
+                "The 'create' argument is deprecated and doesn't do anything.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         cmd_obj = self.command_obj.get(command)
-        if not cmd_obj and create:
+        if not cmd_obj:
             if DEBUG:
                 self.announce(
-                    "Distribution.get_command_obj(): "
-                    f"creating '{command}' command object"
+                    f"Distribution.get_command_obj(): creating '{command}' command object"
                 )
 
             klass = self.get_command_class(command)


### PR DESCRIPTION
See https://github.com/pypa/distutils/pull/343#discussion_r2440177064
> I just did a quick scan through the distutils and setuptools codebase and there's not a single call to `get_finalized_command(..., create=False)`. Maybe the create flag is just cruft that can be eliminated.

Exploratory PR deprecating (unused, but not removed, for backward compatibility) the `create` arg.