### PR TITLE
Fix: Have _resolve_scheme check prefix availability

### DIFF
--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -128,7 +128,7 @@ def _get_implementation():
 
 
 def _select_scheme(ob, name):
-    scheme = _inject_headers(name, _load_scheme(_resolve_scheme(name)))
+    scheme = _inject_headers(name, _load_scheme(_resolve_scheme(ob, name)))
     vars(ob).update(_remove_set(ob, _scheme_attrs(scheme)))
 
 
@@ -139,10 +139,12 @@ def _remove_set(ob, attrs):
     return {key: value for key, value in attrs.items() if getattr(ob, key) is None}
 
 
-def _resolve_scheme(name):
+def _resolve_scheme(ob, name):
     os_name, sep, key = name.partition('_')
     try:
         resolved = sysconfig.get_preferred_scheme(key)
+        if resolved == 'posix_local' and ob.prefix is not None:
+            resolved = 'posix_prefix'
     except Exception:
         resolved = fw.scheme(name)
     return resolved


### PR DESCRIPTION
```py
            if self.prefix is None:
                if self.exec_prefix is not None:
                    raise DistutilsOptionError(
                        "must not supply exec-prefix without prefix"
                    )

                # Allow Fedora to add components to the prefix
                _prefix_addition = getattr(sysconfig, '_prefix_addition', "")

                self.prefix = os.path.normpath(sys.prefix) + _prefix_addition
                self.exec_prefix = os.path.normpath(sys.exec_prefix) + _prefix_addition

            else:
                if self.exec_prefix is None:
                    self.exec_prefix = self.prefix

            self.install_base = self.prefix
            self.install_platbase = self.exec_prefix
            self.select_scheme("posix_prefix")
```

Here _prefix_addition is considered only when self.prefix is only None.

Meanwhile, `select_scheme("posix_prefix")` becomes `select_scheme("posix_local")` on Debian 12+ unconditionally.

self.prefix should be considered.

----

This is basically for `setup.py install --prefix=`. For `pip install --prefix=`, see https://github.com/pypa/pip/pull/13634 .