### PR TITLE
Use float value of ST_MTIME in copy_file function

### DIFF
--- a/distutils/file_util.py
+++ b/distutils/file_util.py
@@ -161,9 +161,9 @@ def copy_file(  # noqa: C901
         # According to David Ascher <da@ski.org>, utime() should be done
         # before chmod() (at least under NT).
         if preserve_times:
-            os.utime(dst, (st[ST_ATIME], st[ST_MTIME]))
+            os.utime(dst, (st.st_atime, st.st_mtime))
         if preserve_mode:
-            os.chmod(dst, S_IMODE(st[ST_MODE]))
+            os.chmod(dst, S_IMODE(st.st_mode))
 
     return (dst, True)
 

--- a/distutils/file_util.py
+++ b/distutils/file_util.py
@@ -161,7 +161,7 @@ def copy_file(  # noqa: C901
         # According to David Ascher <da@ski.org>, utime() should be done
         # before chmod() (at least under NT).
         if preserve_times:
-            os.utime(dst, (st.st_atime, st.st_mtime))
+           os.utime(dst, ns=(st.st_atime_ns, st.st_mtime_ns))
         if preserve_mode:
             os.chmod(dst, S_IMODE(st.st_mode))
 

--- a/distutils/file_util.py
+++ b/distutils/file_util.py
@@ -102,7 +102,7 @@ def copy_file(  # noqa: C901
     # (not update) and (src newer than dst).
 
     from distutils._modified import newer
-    from stat import S_IMODE, ST_ATIME, ST_MODE, ST_MTIME
+    from stat import S_IMODE
 
     if not os.path.isfile(src):
         raise DistutilsFileError(
@@ -161,7 +161,7 @@ def copy_file(  # noqa: C901
         # According to David Ascher <da@ski.org>, utime() should be done
         # before chmod() (at least under NT).
         if preserve_times:
-           os.utime(dst, ns=(st.st_atime_ns, st.st_mtime_ns))
+            os.utime(dst, ns=(st.st_atime_ns, st.st_mtime_ns))
         if preserve_mode:
             os.chmod(dst, S_IMODE(st.st_mode))
 

--- a/distutils/tests/test_file_util.py
+++ b/distutils/tests/test_file_util.py
@@ -93,3 +93,16 @@ class TestFileUtil:
         assert not os.path.samestat(st2, st3), (st2, st3)
         for fn in (self.source, self.target):
             assert fn.read_text(encoding='utf-8') == 'some content'
+
+    def test_copy_file_preserves_mtime(self):
+        """
+        copy_file() with preserve_times reproduces the source's modification
+        time exactly, including sub-second precision, so the copy is never
+        considered older than the source. Ref pypa/setuptools#5079.
+        """
+        jaraco.path.build({self.source: 'some content'})
+        # pick an mtime with a fractional part that is not representable as a
+        # whole number of seconds.
+        os.utime(self.source, ns=(1_234_567_891, 1_234_567_891))
+        copy_file(self.source, self.target)
+        assert os.stat(self.target).st_mtime_ns == os.stat(self.source).st_mtime_ns

--- a/newsfragments/5079.bugfix.rst
+++ b/newsfragments/5079.bugfix.rst
@@ -1,0 +1,1 @@
+``copy_file`` now preserves the full precision of the source's modification time, so a copy is no longer considered older than its source on filesystems with sub-second timestamp resolution. (pypa/distutils#379)


### PR DESCRIPTION
The `copy_file` function uses `st[ST_MTIME]` when copying timestamps which is an int 
whereas the `newer` function uses `os.path.getmtime` which returns a float to check if
a file is outdated. This causes the copied file to always be older than the source file.

This commit updates the `copy_file` function to use `st.st_mtime` which is the float value.

Ref: pypa/setuptools#5079