### PR TITLE
Fix regex tests on Python 3.14

### DIFF
--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -70,7 +70,7 @@ class Compiler:
     # dictionary (see below -- used by the 'new_compiler()' factory
     # function) -- authors of new compiler interface classes are
     # responsible for updating 'compiler_class'!
-    compiler_type: ClassVar[str] = None  # type: ignore[assignment]
+    compiler_type: ClassVar[str] = None
 
     # XXX things not handled by this compiler abstraction model:
     #   * client can't provide additional options for a compiler,

--- a/distutils/tests/test_filelist.py
+++ b/distutils/tests/test_filelist.py
@@ -46,7 +46,7 @@ class TestFileList:
         caplog.clear()
 
     def test_glob_to_re(self):
-        sep = re.escape(os.sep) if os.sep == '\\' else os.sep
+        sep = re.escape(os.sep)
         # https://docs.python.org/3/whatsnew/3.14.html#re
         end_of_str_metachar = r"\z" if sys.version_info >= (3, 14) else r"\Z"
 


### PR DESCRIPTION
Fixes #381 

This updates tests expectations, but alternatively I can update `glob_to_re`'s implementation to always capitalize `\z` so that the result stays consistent across Python versions (at least for as long as `\Z` stays supported, which I guess is gonna be quite a while)