### PR TITLE
BUG: fixed a bug where calling `build_ext.finalize_options` after `define` or `undef` attributes were already set would raise an exception.

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -266,14 +266,14 @@ class build_ext(Command):
         # specified by the 'define' option will be set to '1'.  Multiple
         # symbols can be separated with commas.
 
-        if self.define:
+        if isinstance(self.define, str):
             defines = self.define.split(',')
             self.define = [(symbol, '1') for symbol in defines]
 
         # The option for macros to undefine is also a string from the
         # option parsing, but has to be a list.  Multiple symbols can also
         # be separated with commas here.
-        if self.undef:
+        if isinstance(self.undef, str):
             self.undef = self.undef.split(',')
 
         if self.swig_opts is None:

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -320,6 +320,16 @@ class TestBuildExt(TempdirManager):
         cmd.finalize_options()
         assert cmd.swig_opts == ['1', '2']
 
+        # Check that calling build_ext.finalize_options after
+        # define or undef attributes were already set to their final type doesn't raise
+        cmd = self.build_ext(dist)
+        cmd.define = [("MY_MACRO", "1")]
+        cmd.undef = ["EVIL_MACRO"]
+        cmd.finalize_options()
+
+        assert cmd.define == [("MY_MACRO", "1")]
+        assert cmd.undef == ["EVIL_MACRO"]
+
     def test_check_extensions_list(self):
         dist = Distribution()
         cmd = self.build_ext(dist)

--- a/newsfragments/386.bugfix.rst
+++ b/newsfragments/386.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where calling ``build_ext.finalize_options`` after ``define`` or
+``undef`` attributes were already set would raise an exception.


### PR DESCRIPTION
moved from https://github.com/pypa/setuptools/pull/5084