### PR TITLE
Handle free-threaded builds in build_ext.get_libraries

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -770,13 +770,14 @@ class build_ext(Command):
             from .._msvccompiler import MSVCCompiler
 
             if not isinstance(self.compiler, MSVCCompiler):
-                template = "python%d%d"
-                if self.debug:
-                    template = template + '_d'
-                pythonlib = template % (
+                pythonlib = "python%d%d" % (
                     sys.hexversion >> 24,
                     (sys.hexversion >> 16) & 0xFF,
                 )
+                if is_freethreaded():
+                    pythonlib += 't'
+                if self.debug:
+                    pythonlib += '_d'
                 # don't extend ext.libraries, it may be shared with other
                 # extensions, it is a reference to the original list
                 return ext.libraries + [pythonlib]

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -756,7 +756,7 @@ class build_ext(Command):
             return parts[-2]
         return parts[-1]
 
-    def get_libraries(self, ext: Extension) -> list[str]:  # noqa: C901
+    def get_libraries(self, ext: Extension) -> list[str]:
         """Return the list of libraries to link against when building a
         shared extension.  On most platforms, this is just 'ext.libraries';
         on Windows, we add the Python library (eg. python20.dll).

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -770,14 +770,11 @@ class build_ext(Command):
             from .._msvccompiler import MSVCCompiler
 
             if not isinstance(self.compiler, MSVCCompiler):
-                pythonlib = "python%d%d" % (
-                    sys.hexversion >> 24,
-                    (sys.hexversion >> 16) & 0xFF,
+                pythonlib = (
+                    f"python{sys.hexversion >> 24}{(sys.hexversion >> 16) & 0xFF}"
+                    + 't' * is_freethreaded()
+                    + '_d' * bool(self.debug)
                 )
-                if is_freethreaded():
-                    pythonlib += 't'
-                if self.debug:
-                    pythonlib += '_d'
                 # don't extend ext.libraries, it may be shared with other
                 # extensions, it is a reference to the original list
                 return ext.libraries + [pythonlib]


### PR DESCRIPTION
This updates build_ext.get_libraries to handle free-threaded builds of Python when using non-MSVC compilers.

Previously, the non-free-threaded library would be used for free-threaded builds of Python. For instance, when attempting to build an extension for python314t, the extension would be linked against python314.

This fixes pypa/setuptools#5126.

I've manually tested this by using a similarly patched setuptools to successfully build jq.py wheels using mingw32 on Windows for python314t. While there are some automated tests for build_ext, my impression from a quick look was that those tests rely on being run in the relevant environment, rather than (for instance) mocking the environment, and therefore updating the tests to check this case isn't straightforward.