### PR TITLE
`spawn`/`call`: don't force param `cmd` to be mutable + allow more kwargs on msvc

### DIFF
--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -11,8 +11,8 @@ import os
 import re
 import sys
 from abc import abstractmethod
-from collections.abc import Callable, MutableSequence
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
+from collections.abc import Callable, MutableSequence, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, overload
 
 from . import _modified, archive_util, dir_util, file_util, util
 from ._log import log
@@ -467,6 +467,20 @@ class Command:
         """Move a file respecting dry-run flag."""
         return file_util.move_file(src, dst, dry_run=self.dry_run)
 
+    @overload
+    def spawn(
+        self,
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+        search_path: Literal[False],
+        level: int = 1,
+    ) -> None: ...
+    @overload
+    def spawn(
+        self,
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+        search_path: Literal[True] = True,
+        level: int = 1,
+    ) -> None: ...
     def spawn(
         self, cmd: MutableSequence[str], search_path: bool = True, level: int = 1
     ) -> None:

--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -11,8 +11,15 @@ import os
 import re
 import sys
 from abc import abstractmethod
-from collections.abc import Callable, MutableSequence
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast, overload
+from collections.abc import Callable, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    TypeVar,
+    cast,
+    overload,
+)
 
 from . import _modified, archive_util, dir_util, file_util, util
 from ._log import log
@@ -451,7 +458,7 @@ class Command:
         return file_util.move_file(src, dst)
 
     def spawn(
-        self, cmd: MutableSequence[str], search_path: bool = True, level: int = 1
+        self, cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]]
     ) -> None:
         """Spawn an external command respecting dry-run flag."""
         from distutils.spawn import spawn

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -10,7 +10,7 @@ import pathlib
 import re
 import sys
 import warnings
-from collections.abc import Callable, Iterable, MutableSequence, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import (
     TYPE_CHECKING,
     ClassVar,
@@ -39,6 +39,8 @@ from .errors import (
 )
 
 if TYPE_CHECKING:
+    from subprocess import _ENV
+
     from typing_extensions import TypeAlias, TypeVarTuple, Unpack
 
     _Ts = TypeVarTuple("_Ts")
@@ -70,7 +72,7 @@ class Compiler:
     # dictionary (see below -- used by the 'new_compiler()' factory
     # function) -- authors of new compiler interface classes are
     # responsible for updating 'compiler_class'!
-    compiler_type: ClassVar[str] = None  # type: ignore[assignment]
+    compiler_type: ClassVar[str] = None
 
     # XXX things not handled by this compiler abstraction model:
     #   * client can't provide additional options for a compiler,
@@ -1152,8 +1154,28 @@ int main (int argc, char **argv) {{
     ) -> None:
         execute(func, args, msg, self.dry_run)
 
+    @overload
     def spawn(
-        self, cmd: MutableSequence[bytes | str | os.PathLike[str]], **kwargs
+        self,
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+        *,
+        search_path: Literal[False],
+        verbose: bool = False,
+        env: _ENV | None = None,
+    ) -> None: ...
+    @overload
+    def spawn(
+        self,
+        cmd: Sequence[bytes | str | os.PathLike[str]],
+        *,
+        search_path: Literal[True] = True,
+        verbose: bool = False,
+        env: _ENV | None = None,
+    ) -> None: ...
+    def spawn(
+        self,
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+        **kwargs,
     ) -> None:
         spawn(cmd, dry_run=self.dry_run, **kwargs)
 

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -12,14 +12,8 @@ import shutil
 import subprocess
 import sys
 import warnings
-from collections.abc import Callable, Iterable, MutableSequence, Sequence
-from typing import (
-    TYPE_CHECKING,
-    ClassVar,
-    Literal,
-    TypeVar,
-    overload,
-)
+from collections.abc import Callable, Iterable, Sequence
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, overload
 
 from more_itertools import always_iterable
 
@@ -1167,7 +1161,7 @@ int main (int argc, char **argv) {{
 
     def call(
         self,
-        cmd: MutableSequence[bytes | str | os.PathLike[str]],
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
         *,
         env: _ENV | None = None,
         **kwargs,
@@ -1178,7 +1172,7 @@ int main (int argc, char **argv) {{
 
     def spawn(
         self,
-        cmd: MutableSequence[bytes | str | os.PathLike[str]],
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
         *,
         env: _ENV | None = None,
         **kwargs,

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -17,14 +17,10 @@ import contextlib
 import os
 import subprocess
 import tempfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sequence
+from itertools import count
 from pathlib import Path
 from typing import ClassVar
-
-with contextlib.suppress(ImportError):
-    import winreg
-
-from itertools import count
 
 from ..errors import PlatformError
 from ..logging import get_logger
@@ -32,6 +28,9 @@ from ..platform.detect import get_host_platform, get_platform
 from . import base
 from .base import gen_lib_options
 from .errors import CompileError, LibError, LinkError
+
+with contextlib.suppress(ImportError):
+    import winreg
 
 log = get_logger(__name__)
 
@@ -618,7 +617,13 @@ class Compiler(base.Compiler):
         else:
             log.debug("skipping %s (up-to-date)", output_filename)
 
-    def call(self, cmd, *, env=None, **kwargs):
+    def call(
+        self,
+        cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+        *,
+        env=None,
+        **kwargs,
+    ) -> None:
         env = dict(os.environ, PATH=self._paths)
         return super().call(cmd, env=env, **kwargs)
 

--- a/distutils/compilers/C/tests/test_base.py
+++ b/distutils/compilers/C/tests/test_base.py
@@ -18,7 +18,8 @@ def c_file(tmp_path):
     all_headers = gen_headers + plat_headers
     headers = '\n'.join(f'#include <{header}>\n' for header in all_headers)
     payload = (
-        textwrap.dedent(
+        textwrap
+        .dedent(
             """
         #headers
         void PyInit_foo(void) {}

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -12,8 +12,8 @@ import shutil
 import subprocess
 import sys
 import warnings
-from collections.abc import Mapping, MutableSequence
-from typing import TYPE_CHECKING, TypeVar, overload
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Literal, TypeVar, overload
 
 from ._log import log
 from .debug import DEBUG
@@ -52,8 +52,24 @@ def _resolve(env: _MappingT | None) -> _MappingT | os._Environ[str]:
     return os.environ if env is None else env
 
 
+@overload
 def spawn(
-    cmd: MutableSequence[bytes | str | os.PathLike[str]],
+    cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+    search_path: Literal[False],
+    verbose: bool = False,
+    dry_run: bool = False,
+    env: _ENV | None = None,
+) -> None: ...
+@overload
+def spawn(
+    cmd: Sequence[bytes | str | os.PathLike[str]],
+    search_path: Literal[True] = True,
+    verbose: bool = False,
+    dry_run: bool = False,
+    env: _ENV | None = None,
+) -> None: ...
+def spawn(
+    cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
     search_path: bool = True,
     verbose: bool = False,
     dry_run: bool = False,
@@ -81,7 +97,7 @@ def spawn(
     if search_path:
         executable = shutil.which(cmd[0])
         if executable is not None:
-            cmd[0] = executable
+            cmd = [executable, *cmd[1:]]
 
     try:
         subprocess.check_call(cmd, env=_inject_macos_ver(env))

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -11,10 +11,14 @@ import os
 import subprocess
 import sys
 import warnings
-from collections.abc import MutableSequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 from ._log import log
 from .errors import DistutilsExecError
+
+if TYPE_CHECKING:
+    from subprocess import _ENV
 
 
 @contextlib.contextmanager
@@ -30,7 +34,12 @@ def _translate_errors(cmd):
         ) from err
 
 
-def spawn(cmd: MutableSequence[bytes | str | os.PathLike[str]], **kwargs) -> None:
+def spawn(
+    cmd: Sequence[bytes | os.PathLike[bytes] | str | os.PathLike[str]],
+    *,
+    env: _ENV | None = None,
+    **kwargs,
+) -> None:
     """Run another program, specified as a command list 'cmd', in a new process.
 
     'cmd' is just the argument list for the new process, ie.
@@ -42,7 +51,7 @@ def spawn(cmd: MutableSequence[bytes | str | os.PathLike[str]], **kwargs) -> Non
     """
     log.info(subprocess.list2cmdline(cmd))
     with _translate_errors(cmd):
-        subprocess.check_call(cmd, **kwargs)
+        subprocess.check_call(cmd, env=env, **kwargs)
 
 
 def find_executable(executable: str, path: str | None = None) -> str | None:


### PR DESCRIPTION
This has 2 advantages:
- `cmd` doesn't have to be mutable. So `tuples` are usable
- It actually improves the generic type because `MutableSequence` is invariant. which can cause issues with union types since you need to match the exact full union type (some checkers do allow partial union match for inline/literal sequences)
  - Needed to resolve all mypy `[arg-type]`

I also improved the possible param types by using an overload on `search_path` (since `search_path` allows `bytes | str | PathLike[str]`, but not `PathLike[bytes]`)

Open question: Since `verbose` isn't used in `spawn`, maybe it's better to not even expose it as a possible kwargs in `Compiler` classes ? (no runtime change, just hiding it from the type annotation in wrapper methods)

---

Edit: Updated with https://github.com/pypa/distutils/commit/3f09fab3a3cfd1b2bb86066ad826a665e7712ebf