### PR TITLE
install: correct sysconfig scheme lookup on Windows

### DIFF
--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -142,7 +142,7 @@ def _remove_set(ob, attrs):
 def _resolve_scheme(name):
     os_name, sep, key = name.partition('_')
     try:
-        resolved = sysconfig.get_preferred_scheme(key)
+        resolved = sysconfig.get_preferred_scheme(key or "prefix")
     except Exception:
         resolved = fw.scheme(name)
     return resolved


### PR DESCRIPTION
distutils by default passes os.name, so "nt", to _resolve_scheme() which results in the layout key being "", which results in get_preferred_scheme() raising, and "nt" being returned as as a fallback.

This is not correct in case sysconfig has a different scheme configuration, or in case we are installing into a venv, where the "venv" scheme should be selected and not "nt".

Fix by defaulting to the "prefix" layout in case no layout is given. This gives us "nt" from sysconfig, and "venv" in case we are in a venv. With CPython the change from "nt" to "venv" doesn't change anything for distutils since that only means "headers" are missing, which distutils injects later, resulting in the same scheme paths.

For MINGW Python which defaults to the "posix" scheme this fixes the default
install location (up until now MINGW Python patched the "nt" scheme to work
around this but we want to fix the real issue now)