### PR TITLE
Fixed build_ext assumption that cross-compilation on Windows always uses MSVCCompiler

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -329,10 +329,14 @@ class build_ext(Command):
             force=self.force,
         )
         customize_compiler(self.compiler)
-        # If we are cross-compiling, init the compiler now (if we are not
-        # cross-compiling, init would not hurt, but people may rely on
-        # late initialization of compiler even if they shouldn't...)
-        if os.name == 'nt' and self.plat_name != get_platform():
+        if (
+            # If we are cross-compiling, init the compiler now (if we are not
+            # cross-compiling, init would not hurt, but people may rely on
+            # late initialization of compiler even if they shouldn't...)
+            self.plat_name != get_platform()
+            # Initialization is a MSVCCompiler specific concept
+            and hasattr(self.compiler, "initialize")
+        ):
             self.compiler.initialize(self.plat_name)
 
         # The official Windows free threaded Python installer doesn't set

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -329,14 +329,12 @@ class build_ext(Command):
             force=self.force,
         )
         customize_compiler(self.compiler)
-        if (
-            # If we are cross-compiling, init the compiler now (if we are not
-            # cross-compiling, init would not hurt, but people may rely on
-            # late initialization of compiler even if they shouldn't...)
-            self.plat_name != get_platform()
-            # Initialization is a MSVCCompiler specific concept
-            and hasattr(self.compiler, "initialize")
-        ):
+        # When cross-compiling, initialize the compiler now so it targets
+        # plat_name rather than the host platform. For a native build,
+        # initialization is left lazy, since some builds may rely on it
+        # (e.g. to avoid requiring a compiler that never compiles).
+        # See pypa/distutils#410.
+        if self.plat_name != get_platform():
             self.compiler.initialize(self.plat_name)
 
         # The official Windows free threaded Python installer doesn't set

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -166,6 +166,16 @@ class Compiler:
         for key in self.executables.keys():
             self.set_executable(key, self.executables[key])
 
+    def initialize(self, plat_name: str | None = None) -> None:
+        """Prepare the compiler for use, targeting the given platform.
+
+        Most compilers configure themselves lazily on first use and so
+        need no explicit initialization; for those this is a no-op. A
+        compiler that must be initialized before use (e.g. MSVCCompiler,
+        which resolves a Visual Studio environment) overrides this to
+        honor ``plat_name`` when cross-compiling.
+        """
+
     def set_executables(self, **kwargs: str) -> None:
         """Define the executables (and options for them) that will be run
         to perform the various stages of compilation.  The exact set of

--- a/distutils/compilers/C/tests/test_base.py
+++ b/distutils/compilers/C/tests/test_base.py
@@ -4,9 +4,27 @@ import textwrap
 
 import pytest
 
-from .. import base
+from .. import base, cygwin, msvc, unix
 
 pytestmark = pytest.mark.usefixtures('suppress_path_mangle')
+
+
+def test_initialize_default_is_noop():
+    """
+    Compilers that need no explicit initialization inherit a no-op
+    Compiler.initialize, so build_ext may initialize any cross-compiler
+    without assuming MSVCCompiler (regression test for pypa/distutils#399).
+    """
+    # The base implementation ignores self and accepts a plat_name.
+    assert base.Compiler.initialize(None) is None
+    assert base.Compiler.initialize(None, 'win-amd64') is None
+
+    # Non-MSVC compilers (Unix, Cygwin, MinGW) inherit the no-op...
+    assert unix.Compiler.initialize is base.Compiler.initialize
+    assert cygwin.Compiler.initialize is base.Compiler.initialize
+    assert cygwin.MinGW32Compiler.initialize is base.Compiler.initialize
+    # ...while MSVCCompiler overrides it.
+    assert msvc.Compiler.initialize is not base.Compiler.initialize
 
 
 @pytest.fixture

--- a/newsfragments/+.bugfix.rst
+++ b/newsfragments/+.bugfix.rst
@@ -1,0 +1,1 @@
+``build_ext`` no longer fails when cross-compiling with a compiler other than MSVC (such as MinGW). ``Compiler`` now provides a no-op ``initialize()`` that non-MSVC compilers inherit. (pypa/distutils#399)


### PR DESCRIPTION
Fixes the following error if providing `--plat-name` when using msys2-mingw on Windows:

```py
Traceback (most recent call last):
  File "D:/a/_temp/msys64/mingw64/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
  File "D:/a/_temp/msys64/mingw64/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/mingw64/lib/python3.12/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    return _build_backend().build_wheel(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/build_meta.py", line 438, in build_wheel
    return _build(['bdist_wheel'])
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/build_meta.py", line 429, in _build
    return self._build_with_temp_dir(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/build_meta.py", line 410, in _build_with_temp_dir
    self.run_setup()
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
    exec(code, locals())
  File "<string>", line 1963, in <module>
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)  # type: ignore[return-value]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1000, in run_commands
    self.run_command(cmd)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/dist.py", line 1107, in run_command
    super().run_command(command)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1019, in run_command
    cmd_obj.run()
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/command/bdist_wheel.py", line 370, in run
    self.run_command("build")
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 341, in run_command
    self.distribution.run_command(command)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/dist.py", line 1107, in run_command
    super().run_command(command)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1019, in run_command
    cmd_obj.run()
  File "<string>", line 354, in run
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 341, in run_command
    self.distribution.run_command(command)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/dist.py", line 1107, in run_command
    super().run_command(command)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1019, in run_command
    cmd_obj.run()
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/command/build_ext.py", line 97, in run
    _build_ext.run(self)
  File "D:/a/_temp/msys64/tmp/build-env-g6pjoax9/lib/python3.12/site-packages/setuptools/_distutils/command/build_ext.py", line 336, in run
    self.compiler.initialize(self.plat_name)
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MinGW32Compiler' object has no attribute 'initialize'
```

This could've been caught with static type checking, but `attr-defined` is currently disabled in mypy