### PR TITLE
install: Escape curly brackets in virtualenv path

### DIFF
--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -19,7 +19,13 @@ from ..debug import DEBUG
 from ..errors import DistutilsOptionError, DistutilsPlatformError
 from ..file_util import write_file
 from ..sysconfig import get_config_vars
-from ..util import change_root, convert_path, get_platform, subst_vars
+from ..util import (
+    change_root,
+    convert_path,
+    escape_curly_brackets,
+    get_platform,
+    subst_vars,
+)
 from . import _framework_compat as fw
 
 HAS_USER_SITE = True
@@ -562,8 +568,14 @@ class install(Command):
                 # Allow Fedora to add components to the prefix
                 _prefix_addition = getattr(sysconfig, '_prefix_addition', "")
 
-                self.prefix = os.path.normpath(sys.prefix) + _prefix_addition
-                self.exec_prefix = os.path.normpath(sys.exec_prefix) + _prefix_addition
+                self.prefix = (
+                    escape_curly_brackets(os.path.normpath(sys.prefix))
+                    + _prefix_addition
+                )
+                self.exec_prefix = (
+                    escape_curly_brackets(os.path.normpath(sys.exec_prefix))
+                    + _prefix_addition
+                )
 
             else:
                 if self.exec_prefix is None:
@@ -585,7 +597,7 @@ class install(Command):
             self.select_scheme("posix_home")
         else:
             if self.prefix is None:
-                self.prefix = os.path.normpath(sys.prefix)
+                self.prefix = escape_curly_brackets(os.path.normpath(sys.prefix))
 
             self.install_base = self.install_platbase = self.prefix
             try:

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -185,6 +185,13 @@ def check_environ() -> None:
         os.environ['PLAT'] = get_platform()
 
 
+def escape_curly_brackets(s):
+    """
+    Escape curly brackets in string for format_map
+    """
+    return s.translate(str.maketrans({'{': '{{', '}': '}}'}))
+
+
 def subst_vars(s, local_vars: Mapping[str, object]) -> str:
     """
     Perform variable substitution on 'string'.


### PR DESCRIPTION
#### Summary of error
As mentioned in #281 if a virtual environment contains curly brackets (/path/{W}/project), setuptools fails with the error "ValueError: invalid variable 'W'", which is difficult to diagnose and is readily misattributed to the package being installed.

#### Under the hood
In `distutils.command.install`, `install.finalize_options()` calls `install.expand_basedirs()`, which expands `install.install_base`, `install.install_platbase`, and `install.root` paths using format_map to expand curly bracket variables supported in these paths through --user, --home, --prefix flags, sysconfig, etc..  Without these flags/configs,, sys.prefix and sys.exec_prefix are invoked, for which curly brackets in the path should be interpreted literally.

#### What this PR does
This PR escapes curly brackets when reading `sys.prefix` and `sys.exec_prefix` into `install.prefix` to prevent them from later being interpreted as variables, which resulted in the error.  It assumes that `install.prefix` is always formatted (through `util.subst_vars` and `format_map`) before usage, which appears to be the case.  It does not change the curly bracket expansion behavior of config and flag arguments.

#### Test/MWE
```
mkdir -p /tmp/{W}/project
cd /tmp/{W}/project
virtualenv venv
source venv/bin/activate
pip install -U pip wheel setuptools
pip install --no-build-isolation --no-binary :all: mysqlclient
```

The above fails with "ValueError: invalid variable 'W'" in the current main branch of setuptools and works if this patch is applied to setuptools.  Tests with tox on distutils and patched setuptools appeared to show no relevant errors.

This is my first PR, kindly treat with scrutiny and do not hesitate with feedback.