### PR TITLE
Add support for `.mc` files in `CygwinCCompiler`+`MinGW32Compiler` / Add support for windmc compiling routine

### DIFF
--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -78,7 +78,7 @@ class Compiler:
     #     should be the domain of concrete compiler abstraction classes
     #     (UnixCCompiler, MSVCCompiler, etc.) -- or perhaps the base
     #     class should have methods for the common ones.
-    #   * can't completely override the include or library searchg
+    #   * can't completely override the include or library search
     #     path, ie. no "cc -I -Idir1 -Idir2" or "cc -L -Ldir1 -Ldir2".
     #     I'm not sure how widely supported this is even by Unix
     #     compilers, much less on other platforms.  And I'm even less
@@ -97,7 +97,7 @@ class Compiler:
     # Subclasses that rely on the standard filename generation methods
     # implemented below should override these; see the comment near
     # those methods ('object_filenames()' et. al.) for details:
-    src_extensions: ClassVar[list[str] | None] = None
+    src_extensions: ClassVar[list[str]] = []
     obj_extension: ClassVar[str | None] = None
     static_lib_extension: ClassVar[str | None] = None
     shared_lib_extension: ClassVar[str | None] = None
@@ -371,7 +371,7 @@ class Compiler:
         outdir: str | None,
         macros: list[_Macro] | None,
         incdirs: list[str] | tuple[str, ...] | None,
-        sources,
+        sources: Sequence[str | os.PathLike[str]],
         depends,
         extra,
     ):
@@ -387,7 +387,7 @@ class Compiler:
 
         pp_opts = gen_preprocess_options(macros, incdirs)
 
-        build = {}
+        build: dict[str, tuple[str | os.PathLike[str], str]] = {}
         for i in range(len(sources)):
             src = sources[i]
             obj = objects[i]
@@ -531,7 +531,14 @@ class Compiler:
         newer = newer_group(objects, output_file)
         return newer
 
-    def detect_language(self, sources: str | list[str]) -> str | None:
+    def detect_language(
+        self,
+        sources: str
+        | os.PathLike[str]
+        | list[str]
+        | list[os.PathLike[str]]
+        | list[str | os.PathLike[str]],
+    ) -> str | None:
         """Detect the language of a given file, or list of files. Uses
         language_map, and language_order to do the job.
         """

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -99,7 +99,7 @@ class Compiler:
     # Subclasses that rely on the standard filename generation methods
     # implemented below should override these; see the comment near
     # those methods ('object_filenames()' et. al.) for details:
-    src_extensions: ClassVar[list[str] | None] = None
+    src_extensions: ClassVar[list[str]] = []
     obj_extension: ClassVar[str | None] = None
     static_lib_extension: ClassVar[str | None] = None
     shared_lib_extension: ClassVar[str | None] = None
@@ -391,7 +391,7 @@ class Compiler:
         outdir: str | None,
         macros: list[_Macro] | None,
         incdirs: list[str] | tuple[str, ...] | None,
-        sources,
+        sources: Sequence[str | os.PathLike[str]],
         depends,
         extra,
     ):
@@ -407,7 +407,7 @@ class Compiler:
 
         pp_opts = gen_preprocess_options(macros, incdirs)
 
-        build = {}
+        build: dict[str, tuple[str | os.PathLike[str], str]] = {}
         for i in range(len(sources)):
             src = sources[i]
             obj = objects[i]
@@ -551,7 +551,14 @@ class Compiler:
         newer = newer_group(objects, output_file)
         return newer
 
-    def detect_language(self, sources: str | list[str]) -> str | None:
+    def detect_language(
+        self,
+        sources: str
+        | os.PathLike[str]
+        | list[str]
+        | list[os.PathLike[str]]
+        | list[str | os.PathLike[str]],
+    ) -> str | None:
         """Detect the language of a given file, or list of files. Uses
         language_map, and language_order to do the job.
         """

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -5,7 +5,6 @@ handles the Cygwin port of the GNU C compiler to Windows.  It also contains
 the Mingw32CCompiler class which handles the mingw32 port of GCC (same as
 cygwin in no-cygwin mode).
 """
-
 from __future__ import annotations
 
 import copy
@@ -15,6 +14,7 @@ import shlex
 import sys
 import warnings
 from subprocess import check_output
+from typing import cast
 
 from ...errors import (
     DistutilsExecError,
@@ -45,6 +45,7 @@ class Compiler(unix.Compiler):
     """Handles the Cygwin port of the GNU C compiler to Windows."""
 
     compiler_type = 'cygwin'
+    src_extensions = unix.Compiler.src_extensions + [".mc"]
     obj_extension = ".o"
     static_lib_extension = ".a"
     shared_lib_extension = ".dll.a"
@@ -66,16 +67,25 @@ class Compiler(unix.Compiler):
                 "Compiling may fail because of undefined preprocessor macros."
             )
 
-        self.cc, self.cxx = get_config_vars('CC', 'CXX')
+        self.cc, self.cxx, self.rc, self.mc = get_config_vars(
+            'CC', 'CXX', 'WINDRES', 'WINDMC'
+        )
 
-        # Override 'CC' and 'CXX' environment variables for
+        # Override environment variables for
         # building using MINGW compiler for MSVC python.
         self.cc = os.environ.get('CC', self.cc or 'gcc')
         self.cxx = os.environ.get('CXX', self.cxx or 'g++')
+        self.rc = os.environ.get(  # resource compiler
+            "WINDRES", cast('str', self.rc) or "windres"
+        )
+        self.mc = os.environ.get(  # message compiler
+            "WINDMC", cast('str', self.mc) or "windmc"
+        )
 
         self.linker_dll = self.cc
         self.linker_dll_cxx = self.cxx
         shared_option = "-shared"
+
 
         self.set_executables(
             compiler=f'{self.cc} -mcygwin -O -Wall',
@@ -105,29 +115,36 @@ class Compiler(unix.Compiler):
         with suppress_known_deprecation():
             return LooseVersion("11.2.0")
 
-    def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
-        """Compiles the source by spawning GCC and windres if needed."""
-        if ext in ('.rc', '.res'):
-            # gcc needs '.res' and '.rc' compiled to object files !!!
-            try:
-                self.spawn(["windres", "-i", src, "-o", obj])
-            except DistutilsExecError as msg:
-                raise CompileError(msg)
-        else:  # for other files use the C-compiler
-            try:
-                if self.detect_language(src) == 'c++':
-                    self.spawn(
-                        self.compiler_so_cxx
-                        + cc_args
-                        + [src, '-o', obj]
-                        + extra_postargs
-                    )
+    def _compile(
+        self,
+        obj: str | os.PathLike[str],
+        src: str | os.PathLike[str],
+        ext: str,
+        cc_args: list[str],
+        extra_postargs: list[str],
+        pp_opts,
+    ) -> None:
+        """Compiles the source by spawning GCC and windres, and/or windmc if needed."""
+        try:
+            if ext == ".mc":
+                h_dir = os.path.dirname(src)
+                rc_dir = os.path.dirname(obj)
+                # first compile .mc to .rc and .h file
+                self.spawn([self.mc, "-h", h_dir, "-r", rc_dir, src])
+                # then compile .rc to .res file
+                base, _ = os.path.splitext(os.path.basename(src))
+                src = os.path.join(rc_dir, base + ".rc")
+            if ext in {".rc", ".res", ".mc"}:
+                # gcc needs '.res' and '.rc' compiled to object files !!!
+                self.spawn([self.rc, "-i", src, "-o", obj])
+            else:  # for other files use the C-compiler
+                if self.detect_language(src) == "c++":  # type: ignore[arg-type]
+                    compiler_so = self.compiler_so_cxx
                 else:
-                    self.spawn(
-                        self.compiler_so + cc_args + [src, '-o', obj] + extra_postargs
-                    )
-            except DistutilsExecError as msg:
-                raise CompileError(msg)
+                    compiler_so = self.compiler_so
+                self.spawn(compiler_so + cc_args + [src, "-o", obj] + extra_postargs)
+        except DistutilsExecError as msg:
+            raise CompileError(msg)
 
     def link(
         self,
@@ -238,7 +255,7 @@ class Compiler(unix.Compiler):
         """
         return {
             **super().out_extensions,
-            **{ext: ext + self.obj_extension for ext in ('.res', '.rc')},
+            **{ext: ext + self.obj_extension for ext in ('.res', '.rc', '.mc')},
         }
 
 

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import warnings
 from sysconfig import get_config_vars
+from typing import cast
 
 import packaging.version
 
@@ -44,6 +45,7 @@ class Compiler(unix.Compiler):
 
     compiler_type = 'cygwin'
     description = "Cygwin port of GNU C Compiler for Win32"
+    src_extensions = unix.Compiler.src_extensions + [".mc"]
     obj_extension = ".o"
     static_lib_extension = ".a"
     shared_lib_extension = ".dll.a"
@@ -65,12 +67,20 @@ class Compiler(unix.Compiler):
                 "Compiling may fail because of undefined preprocessor macros."
             )
 
-        self.cc, self.cxx = get_config_vars('CC', 'CXX')
+        self.cc, self.cxx, self.rc, self.mc = get_config_vars(
+            'CC', 'CXX', 'WINDRES', 'WINDMC'
+        )
 
-        # Override 'CC' and 'CXX' environment variables for
+        # Override environment variables for
         # building using MINGW compiler for MSVC python.
         self.cc = os.environ.get('CC', self.cc or 'gcc')
         self.cxx = os.environ.get('CXX', self.cxx or 'g++')
+        self.rc = os.environ.get(  # resource compiler
+            "WINDRES", cast('str', self.rc) or "windres"
+        )
+        self.mc = os.environ.get(  # message compiler
+            "WINDMC", cast('str', self.mc) or "windmc"
+        )
 
         self.linker_dll = self.cc
         self.linker_dll_cxx = self.cxx
@@ -103,29 +113,36 @@ class Compiler(unix.Compiler):
         )
         return packaging.version.Version("11.2.0")
 
-    def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
-        """Compiles the source by spawning GCC and windres if needed."""
-        if ext in ('.rc', '.res'):
-            # gcc needs '.res' and '.rc' compiled to object files !!!
-            try:
-                self.call(["windres", "-i", src, "-o", obj])
-            except (subprocess.CalledProcessError, OSError) as msg:
-                raise CompileError(msg)
-        else:  # for other files use the C-compiler
-            try:
-                if self.detect_language(src) == 'c++':
-                    self.call(
-                        self.compiler_so_cxx
-                        + cc_args
-                        + [src, '-o', obj]
-                        + extra_postargs
-                    )
+    def _compile(
+        self,
+        obj: str | os.PathLike[str],
+        src: str | os.PathLike[str],
+        ext: str,
+        cc_args: list[str],
+        extra_postargs: list[str],
+        pp_opts,
+    ) -> None:
+        """Compiles the source by spawning GCC and windres, and/or windmc if needed."""
+        try:
+            if ext == ".mc":
+                h_dir = os.path.dirname(src)
+                rc_dir = os.path.dirname(obj)
+                # first compile .mc to .rc and .h file
+                self.call([self.mc, "-h", h_dir, "-r", rc_dir, src])
+                # then compile .rc to .res file
+                base, _ = os.path.splitext(os.path.basename(src))
+                src = os.path.join(rc_dir, base + ".rc")
+            if ext in {".rc", ".res", ".mc"}:
+                # gcc needs '.res' and '.rc' compiled to object files !!!
+                self.call([self.rc, "-i", src, "-o", obj])
+            else:  # for other files use the C-compiler
+                if self.detect_language(src) == "c++":
+                    compiler_so = self.compiler_so_cxx
                 else:
-                    self.call(
-                        self.compiler_so + cc_args + [src, '-o', obj] + extra_postargs
-                    )
-            except (subprocess.CalledProcessError, OSError) as msg:
-                raise CompileError(msg)
+                    compiler_so = self.compiler_so
+                self.call(compiler_so + cc_args + [src, "-o", obj] + extra_postargs)
+        except (subprocess.CalledProcessError, OSError) as msg:
+            raise CompileError(msg)
 
     def link(
         self,
@@ -237,7 +254,7 @@ class Compiler(unix.Compiler):
         """
         return {
             **super().out_extensions,
-            **{ext: ext + self.obj_extension for ext in ('.res', '.rc')},
+            **{ext: ext + self.obj_extension for ext in ('.res', '.rc', '.mc')},
         }
 
 

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -163,7 +163,7 @@ class Compiler(base.Compiler):
     # reasonable common default here, but it's not necessarily used on all
     # Unices!
 
-    src_extensions: ClassVar[list[str] | None] = [
+    src_extensions: ClassVar[list[str]] = [
         ".c",
         ".C",
         ".cc",

--- a/distutils/compilers/C/zos.py
+++ b/distutils/compilers/C/zos.py
@@ -106,7 +106,7 @@ _ld_args = {
 class Compiler(unix.Compiler):
     compiler_type = 'zos'
     description = "IBM XL C/C++ Compilers"
-    src_extensions: ClassVar[list[str] | None] = [
+    src_extensions: ClassVar[list[str]] = [
         '.c',
         '.C',
         '.cc',


### PR DESCRIPTION
Port of https://github.com/pypa/setuptools/pull/4742 from @raedrizqie with added type hints and deduplicated try-catch

I noticed this compiler was missing support whilst trying to add first-party MinGW support to pywin32.

Tested at:
- https://github.com/Avasam/pywin32/pull/24
- https://github.com/mhammond/pywin32/pull/2743