### PR TITLE
fix msvc linker bug for huge command line arguments

### DIFF
--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -17,7 +17,6 @@ import contextlib
 import os
 from pathlib import Path
 import subprocess
-import tempfile
 import unittest.mock as mock
 import warnings
 from collections.abc import Iterable
@@ -557,11 +556,10 @@ class Compiler(base.Compiler):
                 # we must pass in the arguments through a file if it is longer
                 # https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files
                 # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
-                if len(subprocess.list2cmdline([self.linker] + ld_args)) > 32767:
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        cmdline = Path(tmpdir) / 'cmdline.txt'
-                        cmdline.write_text('\n'.join(f'"{item}"' for item in ld_args))
-                        self.spawn([self.linker, '@'+str(cmdline)])
+                if len(subprocess.list2cmdline([self.linker] + ld_args)) > 30000:
+                    cmdline = Path(build_temp) / 'cmdline.txt'
+                    cmdline.write_text('\n'.join(f'"{item}"' for item in ld_args), encoding="utf-16")
+                    self.spawn([self.linker, f'@{cmdline}'])
                 else:
                     self.spawn([self.linker] + ld_args)
             except DistutilsExecError as msg:

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -557,7 +557,7 @@ class Compiler(base.Compiler):
                 # we must pass in the arguments through a file if it is longer
                 # https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files
                 # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
-                if len(' '.join(ld_args)) > 30000:
+                if len(subprocess.list2cmdline(ld_args)) > 32767:
                     with tempfile.TemporaryDirectory() as tmpdir:
                         cmdline = Path(tmpdir) / 'cmdline.txt'
                         cmdline.write_text('\n'.join(f'"{item}"' for item in ld_args))

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import contextlib
 import os
+from pathlib import Path
 import subprocess
+import tempfile
 import unittest.mock as mock
 import warnings
 from collections.abc import Iterable
@@ -551,7 +553,17 @@ class Compiler(base.Compiler):
             self.mkpath(output_dir)
             try:
                 log.debug('Executing "%s" %s', self.linker, ' '.join(ld_args))
-                self.spawn([self.linker] + ld_args)
+                # The maximum length of the commandline is 32,767
+                # we must pass in the arguments through a file if it is longer
+                # https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files
+                # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
+                if len(' '.join(ld_args)) > 30000:
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        cmdline = Path(tmpdir) / 'cmdline.txt'
+                        cmdline.write_text('\n'.join(f'"{item}"' for item in ld_args))
+                        self.spawn([self.linker, '@'+str(cmdline)])
+                else:
+                    self.spawn([self.linker] + ld_args)
             except DistutilsExecError as msg:
                 raise LinkError(msg)
         else:

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -557,7 +557,7 @@ class Compiler(base.Compiler):
                 # we must pass in the arguments through a file if it is longer
                 # https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files
                 # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
-                if len(subprocess.list2cmdline(ld_args)) > 32767:
+                if len(subprocess.list2cmdline([self.linker] + ld_args)) > 32767:
                     with tempfile.TemporaryDirectory() as tmpdir:
                         cmdline = Path(tmpdir) / 'cmdline.txt'
                         cmdline.write_text('\n'.join(f'"{item}"' for item in ld_args))

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -254,7 +254,7 @@ def _response_file_content(args: Iterable[str]) -> str:
 
 
 @contextlib.contextmanager
-def _wrap_link_command(cmd: list[str]) -> Iterator[list[str]]:
+def _wrap_link_command(*cmd: str) -> Iterator[list[str]]:
     r"""
     Yield ``cmd`` suitable for :meth:`Compiler.spawn`, honoring the Windows
     maximum command-line length (:data:`_MAX_COMMAND_LENGTH`).
@@ -267,7 +267,7 @@ def _wrap_link_command(cmd: list[str]) -> Iterator[list[str]]:
 
     Short commands pass through unchanged:
 
-    >>> with _wrap_link_command(['link.exe', 'a.obj']) as spawn_cmd:
+    >>> with _wrap_link_command('link.exe', 'a.obj') as spawn_cmd:
     ...     spawn_cmd
     ['link.exe', 'a.obj']
 
@@ -276,15 +276,17 @@ def _wrap_link_command(cmd: list[str]) -> Iterator[list[str]]:
 
     >>> import pathlib
     >>> args = ['/LIBPATH:' + 'x' * 100] * 400
-    >>> with _wrap_link_command(['link.exe', *args]) as spawn_cmd:
+    >>> with _wrap_link_command('link.exe', *args) as spawn_cmd:
+    ...     spawn_cmd  # doctest: +ELLIPSIS
     ...     response_file = pathlib.Path(spawn_cmd[1][1:])
-    ...     [spawn_cmd[0], spawn_cmd[1][:1], response_file.exists()]
-    ['link.exe', '@', True]
+    ...     response_file.exists()
+    ['link.exe', '@...rsp']
+    True
     >>> response_file.exists()
     False
     """
     if len(subprocess.list2cmdline(cmd)) <= _MAX_COMMAND_LENGTH:
-        yield cmd
+        yield list(cmd)
         return
 
     linker, *args = cmd
@@ -620,7 +622,7 @@ class Compiler(base.Compiler):
             self.mkpath(output_dir)
             try:
                 log.debug('Executing "%s" %s', self.linker, ' '.join(ld_args))
-                with _wrap_link_command([self.linker, *ld_args]) as cmd:
+                with _wrap_link_command(self.linker, *ld_args) as cmd:
                     self.spawn(cmd)
             except DistutilsExecError as msg:
                 raise LinkError(msg)

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -20,6 +20,7 @@ import tempfile
 import unittest.mock as mock
 import warnings
 from collections.abc import Iterable, Iterator
+from pathlib import Path
 
 with contextlib.suppress(ImportError):
     import winreg
@@ -290,16 +291,11 @@ def _wrap_link_command(*cmd: str) -> Iterator[list[str]]:
         return
 
     linker, *args = cmd
-    # utf-16 gives the linker an unambiguous, BOM-prefixed encoding. Close the
-    # file before yielding so the linker can open it on Windows.
-    with tempfile.NamedTemporaryFile(
-        'w', suffix='.rsp', encoding='utf-16', delete=False
-    ) as response:
-        response.write(_response_file_content(args))
-    try:
-        yield [linker, f'@{response.name}']
-    finally:
-        os.unlink(response.name)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # utf-16 gives the linker an unambiguous, BOM-prefixed encoding.
+        response_file = Path(tmpdir) / 'link.rsp'
+        response_file.write_text(_response_file_content(args), encoding='utf-16')
+        yield [linker, f'@{response_file}']
 
 
 class Compiler(base.Compiler):

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 
 import contextlib
 import os
-from pathlib import Path
 import subprocess
 import unittest.mock as mock
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from pathlib import Path
 
 with contextlib.suppress(ImportError):
     import winreg
@@ -96,7 +96,8 @@ def _find_vc2017():
             subprocess.CalledProcessError, OSError, UnicodeDecodeError
         ):
             path = (
-                subprocess.check_output([
+                subprocess
+                .check_output([
                     os.path.join(
                         root, "Microsoft Visual Studio", "Installer", "vswhere.exe"
                     ),
@@ -230,6 +231,70 @@ def _get_vcvars_spec(host_platform, platform):
     vc_hp = _vcvars_names[host_platform]
     vc_plat = _vcvars_names[platform]
     return vc_hp if vc_hp == vc_plat else f'{vc_hp}_{vc_plat}'
+
+
+#: Windows limits a process command line to this many characters. See the
+#: `CreateProcess documentation
+#: <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters>`_.
+_MAX_COMMAND_LENGTH = 2**15 - 1
+
+
+def _response_file_content(args: Iterable[str]) -> str:
+    r"""
+    Render ``args`` as the content of a linker response file, one quoted
+    argument per line.
+
+    >>> print(_response_file_content(['/OUT:with space.dll', 'a.obj']))
+    "/OUT:with space.dll"
+    "a.obj"
+    """
+    return '\n'.join(f'"{arg}"' for arg in args)
+
+
+@contextlib.contextmanager
+def _wrap_link_command(cmd: list[str], build_temp: str) -> Iterator[list[str]]:
+    r"""
+    Yield ``cmd`` suitable for :meth:`Compiler.spawn`, honoring the Windows
+    maximum command-line length (:data:`_MAX_COMMAND_LENGTH`).
+
+    When ``cmd`` fits, yield it unchanged. Otherwise write the arguments to a
+    `response file
+    <https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files>`_
+    in ``build_temp`` and yield a command referencing it, removing the file
+    once the command completes.
+
+    Short commands pass through unchanged:
+
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as tmp:
+    ...     with _wrap_link_command(['link.exe', 'a.obj'], tmp) as spawn_cmd:
+    ...         spawn_cmd
+    ['link.exe', 'a.obj']
+
+    Long commands are replaced by a reference to a response file, which is
+    removed once the command completes:
+
+    >>> import pathlib
+    >>> args = ['/LIBPATH:' + 'x' * 100] * 400
+    >>> with tempfile.TemporaryDirectory() as tmp:
+    ...     with _wrap_link_command(['link.exe', *args], tmp) as spawn_cmd:
+    ...         [spawn_cmd[0], spawn_cmd[1][:1], pathlib.Path(spawn_cmd[1][1:]).exists()]
+    ...     sorted(pathlib.Path(tmp).iterdir())
+    ['link.exe', '@', True]
+    []
+    """
+    if len(subprocess.list2cmdline(cmd)) <= _MAX_COMMAND_LENGTH:
+        yield cmd
+        return
+
+    linker, *args = cmd
+    # utf-16 gives the linker an unambiguous, BOM-prefixed encoding.
+    response_file = Path(build_temp) / 'linker-response.txt'
+    response_file.write_text(_response_file_content(args), encoding='utf-16')
+    try:
+        yield [linker, f'@{response_file}']
+    finally:
+        response_file.unlink()
 
 
 class Compiler(base.Compiler):
@@ -552,16 +617,8 @@ class Compiler(base.Compiler):
             self.mkpath(output_dir)
             try:
                 log.debug('Executing "%s" %s', self.linker, ' '.join(ld_args))
-                # The maximum length of the commandline is 32,767
-                # we must pass in the arguments through a file if it is longer
-                # https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files
-                # https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters
-                if len(subprocess.list2cmdline([self.linker] + ld_args)) > 30000:
-                    cmdline = Path(build_temp) / 'cmdline.txt'
-                    cmdline.write_text('\n'.join(f'"{item}"' for item in ld_args), encoding="utf-16")
-                    self.spawn([self.linker, f'@{cmdline}'])
-                else:
-                    self.spawn([self.linker] + ld_args)
+                with _wrap_link_command([self.linker, *ld_args], build_temp) as cmd:
+                    self.spawn(cmd)
             except DistutilsExecError as msg:
                 raise LinkError(msg)
         else:

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 import contextlib
 import os
 import subprocess
+import tempfile
 import unittest.mock as mock
 import warnings
 from collections.abc import Iterable, Iterator
-from pathlib import Path
 
 with contextlib.suppress(ImportError):
     import winreg
@@ -233,10 +233,12 @@ def _get_vcvars_spec(host_platform, platform):
     return vc_hp if vc_hp == vc_plat else f'{vc_hp}_{vc_plat}'
 
 
-#: Windows limits a process command line to this many characters. See the
-#: `CreateProcess documentation
-#: <https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters>`_.
 _MAX_COMMAND_LENGTH = 2**15 - 1
+"""
+Windows limits a process command line to this many characters. See the
+`CreateProcess documentation
+<https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessa#parameters>`_.
+"""
 
 
 def _response_file_content(args: Iterable[str]) -> str:
@@ -252,23 +254,21 @@ def _response_file_content(args: Iterable[str]) -> str:
 
 
 @contextlib.contextmanager
-def _wrap_link_command(cmd: list[str], build_temp: str) -> Iterator[list[str]]:
+def _wrap_link_command(cmd: list[str]) -> Iterator[list[str]]:
     r"""
     Yield ``cmd`` suitable for :meth:`Compiler.spawn`, honoring the Windows
     maximum command-line length (:data:`_MAX_COMMAND_LENGTH`).
 
     When ``cmd`` fits, yield it unchanged. Otherwise write the arguments to a
-    `response file
+    temporary `response file
     <https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#linker-command-files>`_
-    in ``build_temp`` and yield a command referencing it, removing the file
-    once the command completes.
+    and yield a command referencing it, removing the file once the command
+    completes.
 
     Short commands pass through unchanged:
 
-    >>> import tempfile
-    >>> with tempfile.TemporaryDirectory() as tmp:
-    ...     with _wrap_link_command(['link.exe', 'a.obj'], tmp) as spawn_cmd:
-    ...         spawn_cmd
+    >>> with _wrap_link_command(['link.exe', 'a.obj']) as spawn_cmd:
+    ...     spawn_cmd
     ['link.exe', 'a.obj']
 
     Long commands are replaced by a reference to a response file, which is
@@ -276,25 +276,28 @@ def _wrap_link_command(cmd: list[str], build_temp: str) -> Iterator[list[str]]:
 
     >>> import pathlib
     >>> args = ['/LIBPATH:' + 'x' * 100] * 400
-    >>> with tempfile.TemporaryDirectory() as tmp:
-    ...     with _wrap_link_command(['link.exe', *args], tmp) as spawn_cmd:
-    ...         [spawn_cmd[0], spawn_cmd[1][:1], pathlib.Path(spawn_cmd[1][1:]).exists()]
-    ...     sorted(pathlib.Path(tmp).iterdir())
+    >>> with _wrap_link_command(['link.exe', *args]) as spawn_cmd:
+    ...     response_file = pathlib.Path(spawn_cmd[1][1:])
+    ...     [spawn_cmd[0], spawn_cmd[1][:1], response_file.exists()]
     ['link.exe', '@', True]
-    []
+    >>> response_file.exists()
+    False
     """
     if len(subprocess.list2cmdline(cmd)) <= _MAX_COMMAND_LENGTH:
         yield cmd
         return
 
     linker, *args = cmd
-    # utf-16 gives the linker an unambiguous, BOM-prefixed encoding.
-    response_file = Path(build_temp) / 'linker-response.txt'
-    response_file.write_text(_response_file_content(args), encoding='utf-16')
+    # utf-16 gives the linker an unambiguous, BOM-prefixed encoding. Close the
+    # file before yielding so the linker can open it on Windows.
+    with tempfile.NamedTemporaryFile(
+        'w', suffix='.rsp', encoding='utf-16', delete=False
+    ) as response:
+        response.write(_response_file_content(args))
     try:
-        yield [linker, f'@{response_file}']
+        yield [linker, f'@{response.name}']
     finally:
-        response_file.unlink()
+        os.unlink(response.name)
 
 
 class Compiler(base.Compiler):
@@ -617,7 +620,7 @@ class Compiler(base.Compiler):
             self.mkpath(output_dir)
             try:
                 log.debug('Executing "%s" %s', self.linker, ' '.join(ld_args))
-                with _wrap_link_command([self.linker, *ld_args], build_temp) as cmd:
+                with _wrap_link_command([self.linker, *ld_args]) as cmd:
                     self.spawn(cmd)
             except DistutilsExecError as msg:
                 raise LinkError(msg)

--- a/newsfragments/4177.bugfix.rst
+++ b/newsfragments/4177.bugfix.rst
@@ -1,0 +1,1 @@
+The MSVC linker now passes its arguments through a response file when the command line would exceed the Windows maximum length, fixing failures when linking a large number of objects.


### PR DESCRIPTION
Fixes #226 and https://github.com/pypa/setuptools/issues/4177

This is one of two issues that is blocking [flash-attention ](https://github.com/Dao-AILab/flash-attention) using ROCM CK on Windows. The other issue is in CK itself and not a pypa problem.



This is just to make it easier for the flash-attention maintainers to find when looking through their comments.
https://github.com/Dao-AILab/flash-attention/pull/2400
