### PR TITLE
Fix: Add -m64 linker flag for ibm-openxl on z/OS

### DIFF
--- a/distutils/compilers/C/zos.py
+++ b/distutils/compilers/C/zos.py
@@ -93,7 +93,7 @@ _asm_args = {
 }
 
 _ld_args = {
-    'ibm-openxl': [],
+    'ibm-openxl': ['-m64'],
     'ibm-xlclang': ['-Wl,dll', '-q64'],
     'ibm-xlc': ['-Wl,dll', '-q64'],
 }


### PR DESCRIPTION
## Problem
When using `ibm-clang` (without the 64 suffix) to build Python packages on z/OS, setuptools fails to build C extensions with AMODE mismatch errors. The compiler correctly adds `-m64` during compilation to target 64-bit mode, but the linker was missing this flag, causing 31-bit/64-bit linking errors.

## Solution
Add `-m64` to the linker flags for `ibm-openxl` compilers in `distutils/compilers/C/zos.py` to match the compilation flags and ensure consistent 64-bit mode throughout the build process.

## Testing
Tested with both `ibm-clang` and `ibm-clang64` compilers on z/OS. C extensions now build successfully without AMODE errors.

Fixes: Issue https://github.com/pypa/distutils/issues/407