### PR TITLE
Replace deprecated typing.AnyStr with a constrained TypeVar in util.change_root

### DIFF
--- a/distutils/util.py
+++ b/distutils/util.py
@@ -17,7 +17,7 @@ import sys
 import sysconfig
 import tempfile
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, AnyStr
+from typing import TYPE_CHECKING, TypeVar
 
 from jaraco.functools import pass_none
 
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from typing_extensions import TypeVarTuple, Unpack
 
     _Ts = TypeVarTuple("_Ts")
+
+    _StrBytes = TypeVar("_StrBytes", str, bytes)
 
 
 def get_host_platform() -> str:
@@ -140,8 +142,9 @@ def convert_path(pathname: str | os.PathLike[str]) -> str:
 
 
 def change_root(
-    new_root: AnyStr | os.PathLike[AnyStr], pathname: AnyStr | os.PathLike[AnyStr]
-) -> AnyStr:
+    new_root: _StrBytes | os.PathLike[_StrBytes],
+    pathname: _StrBytes | os.PathLike[_StrBytes],
+) -> _StrBytes:
     """Return 'pathname' with 'new_root' prepended.  If 'pathname' is
     relative, this is equivalent to "os.path.join(new_root,pathname)".
     Otherwise, it requires making 'pathname' relative and then joining the


### PR DESCRIPTION
`typing.AnyStr` is deprecated and slated for removal, so this replaces its use in `util.change_root` with an explicit `TypeVar("_StrBytes", str, bytes)` — preserving the same type-checking behavior (bound between `str` and `bytes`).

This originated as @sobolevn's [pypa/setuptools#5232](https://github.com/pypa/setuptools/pull/5232). Since `setuptools/_distutils` is vendored from here and overwritten on each sync, the `util.py` portion of that PR was routed upstream to this repo so it persists; the setuptools-owned parts (`glob.py`, `bdist_egg.py`) were merged there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)