### PR TITLE
Speed up distutils imports on Python 3.15+ by adding `__lazy_modules__`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-max-line-length = 88
-
-# jaraco/skeleton#34
-max-complexity = 10
-
-extend-ignore =
-	# Black creates whitespace before colon
-	E203

--- a/distutils/_dataclass.py
+++ b/distutils/_dataclass.py
@@ -1,6 +1,8 @@
 # This is a private module, but setuptools has the explicit permission to use it.
 from __future__ import annotations
 
+__lazy_modules__ = {"dataclasses", "functools", "warnings"}
+
 import warnings
 from dataclasses import dataclass, fields
 from functools import wraps

--- a/distutils/_modified.py
+++ b/distutils/_modified.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}.errors",
+    "jaraco",
+    "jaraco.functools",
+}
+
 import functools
 import os.path
 from collections.abc import Callable, Iterable

--- a/distutils/_modified.py
+++ b/distutils/_modified.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{__spec__.parent}.errors",
     "jaraco",
     "jaraco.functools",
+    f"{__spec__.parent}.errors",
 }
 
 import functools

--- a/distutils/_msvccompiler.py
+++ b/distutils/_msvccompiler.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"warnings"}
+
 import warnings
 
 from .compilers.C import msvc

--- a/distutils/archive_util.py
+++ b/distutils/archive_util.py
@@ -5,6 +5,19 @@ that sort of thing)."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.dir_util",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.spawn",
+    "grp",
+    "pwd",
+    "types",
+    "zipfile",
+}
+
 import contextlib
 import os
 from collections.abc import Callable

--- a/distutils/archive_util.py
+++ b/distutils/archive_util.py
@@ -12,10 +12,7 @@ __lazy_modules__ = {
     f"{__spec__.parent}.dir_util",
     f"{__spec__.parent}.errors",
     f"{__spec__.parent}.spawn",
-    "grp",
-    "pwd",
     "types",
-    "zipfile",
 }
 
 import contextlib
@@ -31,13 +28,13 @@ from .spawn import spawn
 
 zipfile: ModuleType | None = None
 with contextlib.suppress(ImportError):
-    import zipfile
+    import zipfile  # noqa: LZY101
 
 grp: ModuleType | None = None
 pwd: ModuleType | None = None
 with contextlib.suppress(ImportError):
-    import grp
-    import pwd
+    import grp  # noqa: LZY101
+    import pwd  # noqa: LZY101
 
 
 def _get_gid(name):

--- a/distutils/archive_util.py
+++ b/distutils/archive_util.py
@@ -8,14 +8,11 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
+    "types",
     f"{__spec__.parent}._log",
     f"{__spec__.parent}.dir_util",
     f"{__spec__.parent}.errors",
     f"{__spec__.parent}.spawn",
-    "grp",
-    "pwd",
-    "types",
-    "zipfile",
 }
 
 import contextlib
@@ -31,13 +28,13 @@ from .spawn import spawn
 
 zipfile: ModuleType | None = None
 with contextlib.suppress(ImportError):
-    import zipfile
+    import zipfile  # noqa: LZY101
 
 grp: ModuleType | None = None
 pwd: ModuleType | None = None
 with contextlib.suppress(ImportError):
-    import grp
-    import pwd
+    import grp  # noqa: LZY101
+    import pwd  # noqa: LZY101
 
 
 def _get_gid(name):

--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -1,3 +1,9 @@
+__lazy_modules__ = {
+    f"{__spec__.parent}.compat.numpy",
+    f"{__spec__.parent}.compilers.C.base",
+    f"{__spec__.parent}.compilers.C.errors",
+}
+
 from .compat.numpy import (  # noqa: F401
     _default_compilers,
     compiler_class,

--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -6,6 +6,15 @@ in the distutils.command package.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.errors",
+    "logging",
+    "re",
+}
+
 import logging
 import os
 import re

--- a/distutils/cmd.py
+++ b/distutils/cmd.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
+    "re",
     f"{__spec__.parent}._log",
     f"{__spec__.parent}.errors",
-    "logging",
-    "re",
 }
 
 import logging

--- a/distutils/command/_framework_compat.py
+++ b/distutils/command/_framework_compat.py
@@ -2,6 +2,8 @@
 Backward compatibility for homebrew builds on macOS.
 """
 
+__lazy_modules__ = {"subprocess", "sysconfig"}
+
 import functools
 import os
 import subprocess

--- a/distutils/command/bdist.py
+++ b/distutils/command/bdist.py
@@ -5,6 +5,14 @@ distribution)."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "warnings",
+}
+
 import os
 import warnings
 from collections.abc import Callable

--- a/distutils/command/bdist.py
+++ b/distutils/command/bdist.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
     "warnings",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
 }
 
 import os

--- a/distutils/command/bdist_dumb.py
+++ b/distutils/command/bdist_dumb.py
@@ -4,6 +4,15 @@ Implements the Distutils 'bdist_dumb' command (create a "dumb" built
 distribution -- i.e., just an archive to be unpacked under $prefix or
 $exec_prefix)."""
 
+__lazy_modules__ = {
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dir_util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "typing",
+}
+
 import os
 from distutils._log import log
 from typing import ClassVar

--- a/distutils/command/bdist_dumb.py
+++ b/distutils/command/bdist_dumb.py
@@ -6,11 +6,10 @@ $exec_prefix)."""
 
 __lazy_modules__ = {
     "distutils._log",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dir_util",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
-    "typing",
 }
 
 import os

--- a/distutils/command/bdist_rpm.py
+++ b/distutils/command/bdist_rpm.py
@@ -3,6 +3,16 @@
 Implements the Distutils 'bdist_rpm' command (create RPM source and binary
 distributions)."""
 
+__lazy_modules__ = {
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.debug",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.file_util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
+    "subprocess",
+    "typing",
+}
+
 import os
 import subprocess
 import sys

--- a/distutils/command/bdist_rpm.py
+++ b/distutils/command/bdist_rpm.py
@@ -5,12 +5,12 @@ distributions)."""
 
 __lazy_modules__ = {
     "distutils._log",
+    "subprocess",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.debug",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.file_util",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
-    "subprocess",
-    "typing",
 }
 
 import os

--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -4,6 +4,16 @@ Implements the Distutils 'build' command."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "sysconfig",
+    "typing",
+}
+
 import os
 import sys
 import sysconfig

--- a/distutils/command/build.py
+++ b/distutils/command/build.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
     "sysconfig",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
 }
 
 import os

--- a/distutils/command/build_clib.py
+++ b/distutils/command/build_clib.py
@@ -14,6 +14,16 @@ module."""
 # cut 'n paste.  Sigh.
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
+    "typing",
+}
+
 import os
 from collections.abc import Callable
 from distutils._log import log

--- a/distutils/command/build_clib.py
+++ b/distutils/command/build_clib.py
@@ -18,10 +18,9 @@ __lazy_modules__ = {
     "collections",
     "collections.abc",
     "distutils._log",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
-    "typing",
 }
 
 import os

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -6,6 +6,20 @@ extensions ASAP)."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.extension",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "typing",
+}
+
 import contextlib
 import os
 import re

--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -9,15 +9,12 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    "contextlib",
     "distutils._log",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.extension",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
-    "typing",
 }
 
 import contextlib

--- a/distutils/command/build_py.py
+++ b/distutils/command/build_py.py
@@ -2,6 +2,16 @@
 
 Implements the Distutils 'build_py' command."""
 
+__lazy_modules__ = {
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "glob",
+    "importlib",
+    "importlib.util",
+    "typing",
+}
+
 import glob
 import importlib.util
 import os

--- a/distutils/command/build_py.py
+++ b/distutils/command/build_py.py
@@ -4,12 +4,12 @@ Implements the Distutils 'build_py' command."""
 
 __lazy_modules__ = {
     "distutils._log",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
     "glob",
     "importlib",
     "importlib.util",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
 }
 
 import glob

--- a/distutils/command/build_scripts.py
+++ b/distutils/command/build_scripts.py
@@ -2,6 +2,14 @@
 
 Implements the Distutils 'build_scripts' command."""
 
+__lazy_modules__ = {
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "tokenize",
+    "typing",
+}
+
 import os
 import re
 import tokenize

--- a/distutils/command/build_scripts.py
+++ b/distutils/command/build_scripts.py
@@ -4,10 +4,10 @@ Implements the Distutils 'build_scripts' command."""
 
 __lazy_modules__ = {
     "distutils._log",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
     "tokenize",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
 }
 
 import os

--- a/distutils/command/check.py
+++ b/distutils/command/check.py
@@ -3,6 +3,15 @@
 Implements the Distutils 'check' command.
 """
 
+__lazy_modules__ = {
+    "docutils.frontend",
+    "docutils.nodes",
+    "docutils.parsers",
+    "docutils.parsers.rst",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    "typing",
+}
+
 import contextlib
 from typing import ClassVar
 

--- a/distutils/command/check.py
+++ b/distutils/command/check.py
@@ -4,10 +4,6 @@ Implements the Distutils 'check' command.
 """
 
 __lazy_modules__ = {
-    "docutils.frontend",
-    "docutils.nodes",
-    "docutils.parsers",
-    "docutils.parsers.rst",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     "typing",
 }
@@ -19,9 +15,9 @@ from ..core import Command
 from ..errors import DistutilsSetupError
 
 with contextlib.suppress(ImportError):
-    import docutils.frontend
-    import docutils.nodes
-    import docutils.parsers.rst
+    import docutils.frontend  # noqa: LZY102
+    import docutils.nodes  # noqa: LZY102
+    import docutils.parsers.rst  # noqa: LZY102
     import docutils.utils
 
     class SilentReporter(docutils.utils.Reporter):

--- a/distutils/command/check.py
+++ b/distutils/command/check.py
@@ -4,12 +4,8 @@ Implements the Distutils 'check' command.
 """
 
 __lazy_modules__ = {
-    "docutils.frontend",
-    "docutils.nodes",
-    "docutils.parsers",
-    "docutils.parsers.rst",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
 }
 
 import contextlib
@@ -19,9 +15,9 @@ from ..core import Command
 from ..errors import DistutilsSetupError
 
 with contextlib.suppress(ImportError):
-    import docutils.frontend
-    import docutils.nodes
-    import docutils.parsers.rst
+    import docutils.frontend  # noqa: LZY102
+    import docutils.nodes  # noqa: LZY102
+    import docutils.parsers.rst  # noqa: LZY102
     import docutils.utils
 
     class SilentReporter(docutils.utils.Reporter):

--- a/distutils/command/clean.py
+++ b/distutils/command/clean.py
@@ -4,6 +4,12 @@ Implements the Distutils 'clean' command."""
 
 # contributed by Bastian Kleineidam <calvin@cs.uni-sb.de>, added 2000-03-18
 
+__lazy_modules__ = {
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dir_util",
+    "typing",
+}
+
 import os
 from distutils._log import log
 from typing import ClassVar

--- a/distutils/command/clean.py
+++ b/distutils/command/clean.py
@@ -6,8 +6,8 @@ Implements the Distutils 'clean' command."""
 
 __lazy_modules__ = {
     "distutils._log",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dir_util",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dir_util",
 }
 
 import os

--- a/distutils/command/config.py
+++ b/distutils/command/config.py
@@ -11,6 +11,17 @@ this header file lives".
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
+    "pathlib",
+    "re",
+}
+
 import os
 import pathlib
 import re

--- a/distutils/command/config.py
+++ b/distutils/command/config.py
@@ -20,6 +20,7 @@ __lazy_modules__ = {
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
     "pathlib",
     "re",
+    "typing",
 }
 
 import os

--- a/distutils/command/config.py
+++ b/distutils/command/config.py
@@ -15,11 +15,12 @@ __lazy_modules__ = {
     "collections",
     "collections.abc",
     "distutils._log",
+    "pathlib",
+    "re",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.ccompiler",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
-    "pathlib",
-    "re",
 }
 
 import os

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -4,6 +4,20 @@ Implements the Distutils 'install' command."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "contextlib",
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.debug",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.file_util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "itertools",
+    "sysconfig",
+    "typing",
+}
+
 import collections
 import contextlib
 import itertools

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 __lazy_modules__ = {
     "collections",
+    "collections.abc",
     "contextlib",
     "distutils._log",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.debug",

--- a/distutils/command/install.py
+++ b/distutils/command/install.py
@@ -6,16 +6,17 @@ from __future__ import annotations
 
 __lazy_modules__ = {
     "collections",
+    "collections.abc",
     "contextlib",
     "distutils._log",
+    "itertools",
+    "sysconfig",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.debug",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.file_util",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.sysconfig",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
-    "itertools",
-    "sysconfig",
-    "typing",
 }
 
 import collections

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -7,6 +7,14 @@ platform-independent data files."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "functools",
+    "typing",
+}
+
 import functools
 import os
 from collections.abc import Iterable

--- a/distutils/command/install_data.py
+++ b/distutils/command/install_data.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
-    "functools",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
 }
 
 import functools

--- a/distutils/command/install_egg_info.py
+++ b/distutils/command/install_egg_info.py
@@ -5,6 +5,8 @@ Implements the Distutils 'install_egg_info' command, for installing
 a package's PKG-INFO metadata.
 """
 
+__lazy_modules__ = {f"{(__spec__.parent or '').rsplit('.', 1)[0]}._log", "re", "typing"}
+
 import os
 import re
 import sys

--- a/distutils/command/install_egg_info.py
+++ b/distutils/command/install_egg_info.py
@@ -5,7 +5,7 @@ Implements the Distutils 'install_egg_info' command, for installing
 a package's PKG-INFO metadata.
 """
 
-__lazy_modules__ = {f"{(__spec__.parent or '').rsplit('.', 1)[0]}._log", "re", "typing"}
+__lazy_modules__ = {"re", "typing", f"{(__spec__.parent or '').rsplit('.', 1)[0]}._log"}
 
 import os
 import re

--- a/distutils/command/install_headers.py
+++ b/distutils/command/install_headers.py
@@ -3,6 +3,8 @@
 Implements the Distutils 'install_headers' command, to install C/C++ header
 files to the Python include directory."""
 
+__lazy_modules__ = {"typing"}
+
 from typing import ClassVar
 
 from ..core import Command

--- a/distutils/command/install_lib.py
+++ b/distutils/command/install_lib.py
@@ -5,6 +5,13 @@ Implements the Distutils 'install_lib' command
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    "importlib",
+    "importlib.util",
+    "typing",
+}
+
 import importlib.util
 import os
 import sys

--- a/distutils/command/install_lib.py
+++ b/distutils/command/install_lib.py
@@ -6,10 +6,10 @@ Implements the Distutils 'install_lib' command
 from __future__ import annotations
 
 __lazy_modules__ = {
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     "importlib",
     "importlib.util",
     "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
 }
 
 import importlib.util

--- a/distutils/command/install_scripts.py
+++ b/distutils/command/install_scripts.py
@@ -5,6 +5,8 @@ Python scripts."""
 
 # contributed by Bastian Kleineidam
 
+__lazy_modules__ = {"distutils._log", "typing"}
+
 import os
 from distutils._log import log
 from stat import ST_MODE

--- a/distutils/command/sdist.py
+++ b/distutils/command/sdist.py
@@ -4,6 +4,19 @@ Implements the Distutils 'sdist' command (create a source distribution)."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils._log",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.filelist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.text_file",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
+    "glob",
+    "itertools",
+    "typing",
+}
+
 import os
 import sys
 from collections.abc import Callable

--- a/distutils/command/sdist.py
+++ b/distutils/command/sdist.py
@@ -8,13 +8,13 @@ __lazy_modules__ = {
     "collections",
     "collections.abc",
     "distutils._log",
+    "glob",
+    "itertools",
+    "typing",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.filelist",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.text_file",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.util",
-    "glob",
-    "itertools",
-    "typing",
 }
 
 import os

--- a/distutils/compat/__init__.py
+++ b/distutils/compat/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/distutils/compat/numpy.py
+++ b/distutils/compat/numpy.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {f"{(__spec__.parent or '').rsplit('.', 1)[0]}.compilers.C.base"}
+
 # required for older numpy versions on Pythons prior to 3.12; see pypa/setuptools#4876
 from ..compilers.C.base import _default_compilers  # noqa: F401
 

--- a/distutils/compat/py310.py
+++ b/distutils/compat/py310.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"collections", "collections.abc"}
+
 import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeVar

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -5,6 +5,23 @@ for the Distutils compiler abstraction model."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.dir_util",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.file_util",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.spawn",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.util",
+    f"{__spec__.parent}.errors",
+    "more_itertools",
+    "pathlib",
+    "re",
+    "warnings",
+}
+
 import os
 import pathlib
 import re

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -8,17 +8,16 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._modified",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.dir_util",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.file_util",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.spawn",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.detect",
     f"{__spec__.parent}.errors",
     "more_itertools",
     "pathlib",
     "re",
+    "shutil",
     "warnings",
 }
 

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -8,18 +8,17 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._modified",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.dir_util",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.file_util",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.spawn",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.util",
-    f"{__spec__.parent}.errors",
     "more_itertools",
     "pathlib",
     "re",
+    "shutil",
     "warnings",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.detect",
+    f"{__spec__.parent}.errors",
 }
 
 import os

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -8,6 +8,19 @@ cygwin in no-cygwin mode).
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "copy",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.file_util",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.sysconfig",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.version",
+    f"{__spec__.parent}.errors",
+    "pathlib",
+    "shlex",
+    "subprocess",
+    "warnings",
+}
+
 import copy
 import os
 import pathlib

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -10,14 +10,15 @@ from __future__ import annotations
 
 __lazy_modules__ = {
     "copy",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.file_util",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.sysconfig",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.version",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.detect",
     f"{__spec__.parent}.errors",
+    "packaging",
+    "packaging.version",
     "pathlib",
     "shlex",
     "subprocess",
+    "sysconfig",
     "warnings",
 }
 

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -10,15 +10,16 @@ from __future__ import annotations
 
 __lazy_modules__ = {
     "copy",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.file_util",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.sysconfig",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.version",
-    f"{__spec__.parent}.errors",
+    "packaging",
+    "packaging.version",
     "pathlib",
     "shlex",
     "subprocess",
+    "sysconfig",
     "warnings",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.detect",
+    f"{__spec__.parent}.errors",
 }
 
 import copy

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -13,6 +13,24 @@ This module requires VS 2015 or later.
 # ported to VS 2015 by Steve Dower
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.util",
+    f"{__spec__.parent}.base",
+    f"{__spec__.parent}.errors",
+    "itertools",
+    "pathlib",
+    "subprocess",
+    "tempfile",
+    "unittest",
+    "unittest.mock",
+    "warnings",
+    "winreg",
+}
+
 import contextlib
 import os
 import subprocess

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -16,19 +16,15 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.detect",
     f"{__spec__.parent}.base",
     f"{__spec__.parent}.errors",
     "itertools",
     "pathlib",
     "subprocess",
     "tempfile",
-    "unittest",
-    "unittest.mock",
-    "warnings",
-    "winreg",
+    "typing",
 }
 
 import contextlib
@@ -40,7 +36,7 @@ from pathlib import Path
 from typing import ClassVar
 
 with contextlib.suppress(ImportError):
-    import winreg
+    import winreg  # noqa: LZY101
 
 from itertools import count
 

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -16,19 +16,16 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.util",
-    f"{__spec__.parent}.base",
-    f"{__spec__.parent}.errors",
     "itertools",
     "pathlib",
     "subprocess",
     "tempfile",
-    "unittest",
-    "unittest.mock",
-    "warnings",
+    "typing",
     "winreg",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.detect",
+    f"{__spec__.parent}.base",
+    f"{__spec__.parent}.errors",
 }
 
 import contextlib
@@ -40,7 +37,7 @@ from pathlib import Path
 from typing import ClassVar
 
 with contextlib.suppress(ImportError):
-    import winreg
+    import winreg  # noqa: LZY101
 
 from itertools import count
 

--- a/distutils/compilers/C/tests/test_base.py
+++ b/distutils/compilers/C/tests/test_base.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"platform", "sysconfig", "textwrap"}
+
 import platform
 import sysconfig
 import textwrap

--- a/distutils/compilers/C/tests/test_cygwin.py
+++ b/distutils/compilers/C/tests/test_cygwin.py
@@ -1,5 +1,7 @@
 """Tests for the Cygwin C compiler."""
 
+__lazy_modules__ = {"sysconfig"}
+
 import os
 import sys
 import sysconfig

--- a/distutils/compilers/C/tests/test_mingw.py
+++ b/distutils/compilers/C/tests/test_mingw.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._util",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+}
+
 import pytest
 
 from ... import errors

--- a/distutils/compilers/C/tests/test_msvc.py
+++ b/distutils/compilers/C/tests/test_msvc.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors"}
+
 import os
 import sys
 import sysconfig

--- a/distutils/compilers/C/tests/test_unix.py
+++ b/distutils/compilers/C/tests/test_unix.py
@@ -1,5 +1,13 @@
 """Tests for distutils.unixccompiler."""
 
+__lazy_modules__ = {
+    "sysconfig",
+    "test",
+    "test.support",
+    "unittest",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.platform",
+}
+
 import os
 import sys
 import sysconfig

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -15,6 +15,21 @@ the "typical" Unix-style command-line C compiler:
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._macos_compat",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.compat",
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+    f"{__spec__.parent}.base",
+    f"{__spec__.parent}.errors",
+    "itertools",
+    "re",
+    "shlex",
+}
+
 import itertools
 import os
 import re

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -18,16 +18,17 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._macos_compat",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._modified",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.compat",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.macos",
     f"{__spec__.parent}.base",
     f"{__spec__.parent}.errors",
     "itertools",
     "re",
     "shlex",
+    "subprocess",
+    "sysconfig",
+    "typing",
 }
 
 import itertools

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -18,16 +18,17 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._log",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._macos_compat",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}._modified",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.compat",
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{__spec__.parent}.base",
-    f"{__spec__.parent}.errors",
     "itertools",
     "re",
     "shlex",
+    "subprocess",
+    "sysconfig",
+    "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._modified",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.platform.macos",
+    f"{__spec__.parent}.base",
+    f"{__spec__.parent}.errors",
 }
 
 import itertools

--- a/distutils/compilers/C/zos.py
+++ b/distutils/compilers/C/zos.py
@@ -11,6 +11,11 @@ IBM XL C/C++ V2.4.1 for z/OS 2.4 and 2.5
 IBM z/OS XL C/C++
 """
 
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
+    f"{__spec__.parent}.errors",
+}
+
 import os
 import subprocess
 import sysconfig

--- a/distutils/compilers/C/zos.py
+++ b/distutils/compilers/C/zos.py
@@ -11,10 +11,7 @@ IBM XL C/C++ V2.4.1 for z/OS 2.4 and 2.5
 IBM z/OS XL C/C++
 """
 
-__lazy_modules__ = {
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{__spec__.parent}.errors",
-}
+__lazy_modules__ = {f"{__spec__.parent}.errors", "subprocess", "sysconfig", "typing"}
 
 import os
 import subprocess

--- a/distutils/compilers/C/zos.py
+++ b/distutils/compilers/C/zos.py
@@ -11,10 +11,7 @@ IBM XL C/C++ V2.4.1 for z/OS 2.4 and 2.5
 IBM z/OS XL C/C++
 """
 
-__lazy_modules__ = {
-    f"{(__spec__.parent or '').rsplit('.', 2)[0]}.errors",
-    f"{__spec__.parent}.errors",
-}
+__lazy_modules__ = {"subprocess", "sysconfig", "typing", f"{__spec__.parent}.errors"}
 
 import os
 import subprocess

--- a/distutils/compilers/_modified.py
+++ b/distutils/compilers/_modified.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"collections", "collections.abc"}
+
 import os.path
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Literal

--- a/distutils/compilers/logging.py
+++ b/distutils/compilers/logging.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"logging"}
+
 import logging
 
 

--- a/distutils/compilers/platform/detect.py
+++ b/distutils/compilers/platform/detect.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {"sysconfig"}
+
 import os
 import sys
 import sysconfig

--- a/distutils/compilers/platform/macos.py
+++ b/distutils/compilers/platform/macos.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "_osx_support",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    "platform",
+    "sysconfig",
+}
+
 import os
 import platform
 import sys

--- a/distutils/compilers/platform/macos.py
+++ b/distutils/compilers/platform/macos.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "_osx_support",
+    "platform",
+    "sysconfig",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+}
+
 import os
 import platform
 import sys

--- a/distutils/core.py
+++ b/distutils/core.py
@@ -8,6 +8,17 @@ really defined in distutils.dist and distutils.cmd.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}.cmd",
+    f"{__spec__.parent}.debug",
+    f"{__spec__.parent}.dist",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.extension",
+    "tokenize",
+}
+
 import os
 import sys
 import tokenize

--- a/distutils/core.py
+++ b/distutils/core.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
+    "tokenize",
     f"{__spec__.parent}.cmd",
     f"{__spec__.parent}.debug",
     f"{__spec__.parent}.dist",
     f"{__spec__.parent}.errors",
     f"{__spec__.parent}.extension",
-    "tokenize",
 }
 
 import os

--- a/distutils/cygwinccompiler.py
+++ b/distutils/cygwinccompiler.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {f"{__spec__.parent}.compilers.C.cygwin"}
+
 from .compilers.C import cygwin
 from .compilers.C.cygwin import (
     CONFIG_H_NOTOK,

--- a/distutils/dep_util.py
+++ b/distutils/dep_util.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"warnings"}
+
 import warnings
 
 from . import _modified

--- a/distutils/dir_util.py
+++ b/distutils/dir_util.py
@@ -2,6 +2,13 @@
 
 Utility functions for manipulating directories and directory trees."""
 
+__lazy_modules__ = {
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.errors",
+    "itertools",
+    "pathlib",
+}
+
 import functools
 import itertools
 import os

--- a/distutils/dir_util.py
+++ b/distutils/dir_util.py
@@ -3,10 +3,10 @@
 Utility functions for manipulating directories and directory trees."""
 
 __lazy_modules__ = {
-    f"{__spec__.parent}._log",
-    f"{__spec__.parent}.errors",
     "itertools",
     "pathlib",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.errors",
 }
 
 import functools

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -6,6 +6,25 @@ being built/installed/distributed.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    "email",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.debug",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.fancy_getopt",
+    f"{__spec__.parent}.util",
+    "jaraco",
+    "jaraco.text",
+    "logging",
+    "packaging",
+    "packaging.utils",
+    "pathlib",
+    "warnings",
+}
+
 import contextlib
 import logging
 import os

--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -11,18 +11,16 @@ __lazy_modules__ = {
     "collections.abc",
     "contextlib",
     "email",
-    f"{__spec__.parent}._log",
-    f"{__spec__.parent}.debug",
-    f"{__spec__.parent}.errors",
-    f"{__spec__.parent}.fancy_getopt",
-    f"{__spec__.parent}.util",
     "jaraco",
     "jaraco.text",
-    "logging",
     "packaging",
     "packaging.utils",
     "pathlib",
     "warnings",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.debug",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.util",
 }
 
 import contextlib

--- a/distutils/errors.py
+++ b/distutils/errors.py
@@ -5,6 +5,8 @@ Distutils modules may raise these or standard exceptions,
 including :exc:`SystemExit`.
 """
 
+__lazy_modules__ = {f"{__spec__.parent}.compilers.C.errors"}
+
 # compiler exceptions re-exported for backward compatibility; listed in
 # __all__ below so they're recognized as intentional public re-exports.
 from .compilers.C.errors import CompileError, LibError, LinkError, PreprocessError

--- a/distutils/extension.py
+++ b/distutils/extension.py
@@ -5,6 +5,8 @@ modules in setup scripts."""
 
 from __future__ import annotations
 
+__lazy_modules__ = {"collections", "collections.abc"}
+
 import os
 from collections.abc import Iterable
 from dataclasses import field, fields

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -10,6 +10,14 @@ additional features:
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}.errors",
+    "getopt",
+    "typing",
+}
+
 import getopt
 import re
 import string

--- a/distutils/fancy_getopt.py
+++ b/distutils/fancy_getopt.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{__spec__.parent}.errors",
     "getopt",
     "typing",
+    f"{__spec__.parent}.errors",
 }
 
 import getopt

--- a/distutils/file_util.py
+++ b/distutils/file_util.py
@@ -3,6 +3,8 @@
 Utility functions for operating on single files.
 """
 
+__lazy_modules__ = {f"{__spec__.parent}._log", f"{__spec__.parent}.errors"}
+
 import os
 
 from ._log import log

--- a/distutils/filelist.py
+++ b/distutils/filelist.py
@@ -6,6 +6,18 @@ and building lists of files.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.util",
+    "fnmatch",
+    "functools",
+    "re",
+    "typing",
+}
+
 import fnmatch
 import functools
 import os

--- a/distutils/filelist.py
+++ b/distutils/filelist.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{__spec__.parent}._log",
-    f"{__spec__.parent}.errors",
-    f"{__spec__.parent}.util",
     "fnmatch",
     "functools",
     "re",
-    "typing",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.util",
 }
 
 import fnmatch

--- a/distutils/log.py
+++ b/distutils/log.py
@@ -4,6 +4,8 @@ A simple log mechanism styled after PEP 282.
 Retained for compatibility and should not be used.
 """
 
+__lazy_modules__ = {"warnings"}
+
 import logging
 import warnings
 

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -7,12 +7,11 @@ specific functions for launching another program in a sub-process.
 from __future__ import annotations
 
 __lazy_modules__ = {
+    "collections",
+    "collections.abc",
     f"{__spec__.parent}._log",
-    f"{__spec__.parent}.debug",
     f"{__spec__.parent}.errors",
-    "contextlib",
-    "platform",
-    "shutil",
+    "subprocess",
     "warnings",
 }
 

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -6,6 +6,16 @@ specific functions for launching another program in a sub-process.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.debug",
+    f"{__spec__.parent}.errors",
+    "contextlib",
+    "platform",
+    "shutil",
+    "warnings",
+}
+
 import contextlib
 import os
 import subprocess

--- a/distutils/spawn.py
+++ b/distutils/spawn.py
@@ -7,13 +7,12 @@ specific functions for launching another program in a sub-process.
 from __future__ import annotations
 
 __lazy_modules__ = {
-    f"{__spec__.parent}._log",
-    f"{__spec__.parent}.debug",
-    f"{__spec__.parent}.errors",
-    "contextlib",
-    "platform",
-    "shutil",
+    "collections",
+    "collections.abc",
+    "subprocess",
     "warnings",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}.errors",
 }
 
 import contextlib

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -11,6 +11,14 @@ Email:        <fdrake@acm.org>
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    f"{__spec__.parent}.ccompiler",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.util",
+    "pathlib",
+    "sysconfig",
+}
+
 import functools
 import os
 import pathlib

--- a/distutils/sysconfig.py
+++ b/distutils/sysconfig.py
@@ -12,11 +12,11 @@ Email:        <fdrake@acm.org>
 from __future__ import annotations
 
 __lazy_modules__ = {
+    "pathlib",
+    "sysconfig",
     f"{__spec__.parent}.ccompiler",
     f"{__spec__.parent}.errors",
     f"{__spec__.parent}.util",
-    "pathlib",
-    "sysconfig",
 }
 
 import functools

--- a/distutils/text_file.py
+++ b/distutils/text_file.py
@@ -4,6 +4,8 @@ provides the TextFile class, which gives an interface to text files
 that (optionally) takes care of stripping comments, ignoring blank
 lines, and joining lines with backslashes."""
 
+__lazy_modules__ = {"typing"}
+
 import sys
 from typing import ClassVar
 

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -6,6 +6,21 @@ one of the other *util.py modules.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}._modified",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.spawn",
+    "importlib",
+    "importlib.util",
+    "pathlib",
+    "subprocess",
+    "sysconfig",
+    "tempfile",
+}
+
 import functools
 import importlib.util
 import os

--- a/distutils/util.py
+++ b/distutils/util.py
@@ -9,16 +9,16 @@ from __future__ import annotations
 __lazy_modules__ = {
     "collections",
     "collections.abc",
-    f"{__spec__.parent}._log",
-    f"{__spec__.parent}._modified",
-    f"{__spec__.parent}.errors",
-    f"{__spec__.parent}.spawn",
     "importlib",
     "importlib.util",
     "pathlib",
     "subprocess",
     "sysconfig",
     "tempfile",
+    f"{__spec__.parent}._log",
+    f"{__spec__.parent}._modified",
+    f"{__spec__.parent}.errors",
+    f"{__spec__.parent}.spawn",
 }
 
 import functools

--- a/distutils/version.py
+++ b/distutils/version.py
@@ -26,6 +26,8 @@ Every version number class implements the following interface:
     of the same class, thus must follow the same rules)
 """
 
+__lazy_modules__ = {"re", "warnings"}
+
 import contextlib
 import re
 import warnings

--- a/distutils/version.py
+++ b/distutils/version.py
@@ -26,7 +26,7 @@ Every version number class implements the following interface:
     of the same class, thus must follow the same rules)
 """
 
-__lazy_modules__ = {"re", "warnings"}
+__lazy_modules__ = {"warnings"}
 
 import contextlib
 import re

--- a/newsfragments/+414.feature.rst
+++ b/newsfragments/+414.feature.rst
@@ -1,0 +1,1 @@
+Speed up distutils imports on Python 3.15+ by adding ``__lazy_modules__`` -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ doc = [
 check = [
 	"pytest-checkdocs >= 2.14",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
+	"flake8-lazy" # Until Ruff gains support for automatically inserting and validating __lazy_modules__
 ]
 
 cover = [

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,12 @@ pass_env =
 	DISTUTILS_TEST_DEFAULT_COMPILER
 commands =
 	pytest {posargs}
+	# flake8-lazy has no pytest plugin; run its CLI over the package sources.
+	# tox doesn't shell-glob, so expand the file list cross-platform via Python
+	# and drop test dirs (lazy-import hygiene is irrelevant there).
+	python -c "import glob, os, subprocess, sys; \
+		files = [f for f in glob.glob('distutils/**/*.py', recursive=True) if 'tests' not in f.split(os.sep)]; \
+		subprocess.check_call([sys.executable, '-m', 'flake8_lazy', *files])"
 usedevelop = True
 extras =
 	test

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,11 @@ pass_env =
 commands =
 	pytest {posargs}
 	# flake8-lazy has no pytest plugin; run its CLI over the package sources.
-	# Avoid vendored/distutils trees (maintained upstream, not our lazy-import concern).
-	# As well as test dirs (lazy-import hygiene is irrelevant there).
-	python -m flake8_lazy distutils/*.py distutils/command/ distutils/compat/ distutils/compilers/ --apply=set --strict-typing
+	# tox doesn't shell-glob, so expand the file list cross-platform via Python
+	# and drop test dirs (lazy-import hygiene is irrelevant there).
+	python -c "import glob, os, subprocess, sys; \
+		files = [f for f in glob.glob('distutils/**/*.py', recursive=True) if 'tests' not in f.split(os.sep)]; \
+		subprocess.check_call([sys.executable, '-m', 'flake8_lazy', *files])"
 usedevelop = True
 extras =
 	test

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,10 @@ pass_env =
 	DISTUTILS_TEST_DEFAULT_COMPILER
 commands =
 	pytest {posargs}
+	# flake8-lazy has no pytest plugin; run its CLI over the package sources.
+	# Avoid vendored/distutils trees (maintained upstream, not our lazy-import concern).
+	# As well as test dirs (lazy-import hygiene is irrelevant there).
+	python -m flake8_lazy distutils/*.py distutils/command/ distutils/compat/ distutils/compilers/ --apply=set --strict-typing
 usedevelop = True
 extras =
 	test


### PR DESCRIPTION
Alternative dynamic mode: https://flake8-lazy.readthedocs.io/en/latest/cli/#dynamic-mode

Works towards:
- https://github.com/pypa/setuptools/issues/3585
- https://github.com/pypa/setuptools/issues/3441

The same changes would have to be done on setuptools side to close those issues. (https://github.com/pypa/setuptools/pull/5257)

Autofixed by running

```py
import glob, os, subprocess, sys;
files = [f for f in glob.glob('distutils/**/*.py', recursive=True) if 'tests' not in f.split(os.sep)];
subprocess.check_call([sys.executable, '-m', 'flake8_lazy', '--strict-typing', *files, '--apply=set'])
```