### PR TITLE
add compresslevel to archive_util.make_tarball, fix test_archive_util

### DIFF
--- a/distutils/archive_util.py
+++ b/distutils/archive_util.py
@@ -60,11 +60,14 @@ def make_tarball(
     verbose: bool = False,
     owner: str | None = None,
     group: str | None = None,
+    compresslevel: int | None = None,
 ) -> str:
     """Create a (possibly compressed) tar file from all the files under
     'base_dir'.
 
     'compress' must be "gzip" (the default), "bzip2", "xz", or None.
+    If 'compress' is "gzip" or "bzip2", 'compresslevel' can be set to a
+    value between 1 and 9 to tune the compression level.
 
     'owner' and 'group' can be used to define an owner and a group for the
     archive that is being built. If not provided, the current owner and group
@@ -111,7 +114,12 @@ def make_tarball(
             tarinfo.uname = owner
         return tarinfo
 
-    tar = tarfile.open(archive_name, f'w|{tar_compression[compress]}')  # type: ignore[call-overload] # Dynamic mode
+    # set compression level if supported
+    open_kw = {}
+    if compresslevel and compress in ('gzip', 'bzip2'):
+        open_kw['compresslevel'] = compresslevel
+
+    tar = tarfile.open(archive_name, f'w|{tar_compression[compress]}', **open_kw)  # type: ignore[call-overload] # Dynamic mode
     try:
         tar.add(base_dir, filter=_set_uid_gid)
     finally:

--- a/distutils/tests/test_archive_util.py
+++ b/distutils/tests/test_archive_util.py
@@ -4,6 +4,7 @@ import functools
 import operator
 import os
 import pathlib
+import shutil  # noqa: F401  # import used by skipIf
 import sys
 import tarfile
 from distutils import archive_util
@@ -17,6 +18,8 @@ from distutils.archive_util import (
 from distutils.spawn import spawn
 from distutils.tests import support
 from os.path import splitdrive
+from time import perf_counter
+from unittest import TestCase
 
 import path
 import pytest
@@ -46,7 +49,7 @@ def same_drive(*paths):
     return all_equal(pathlib.Path(path).drive for path in paths)
 
 
-class ArchiveUtilTestCase(support.TempdirManager):
+class TestArchiveUtil(TestCase, support.TempdirManager):
     @pytest.mark.usefixtures('needs_zlib')
     def test_make_tarball(self, name='archive'):
         # creating something to tar
@@ -54,6 +57,18 @@ class ArchiveUtilTestCase(support.TempdirManager):
         self._make_tarball(tmpdir, name, '.tar.gz')
         # trying an uncompressed one
         self._make_tarball(tmpdir, name, '.tar', compress=None)
+
+        # trying compression level 1 and 9, where 1 must be faster than 9
+        start_1 = perf_counter()
+        self._make_tarball(tmpdir, name, '.tar.gz', compresslevel=1)
+        end_1 = perf_counter()
+        duration_1 = end_1 - start_1
+        start_9 = perf_counter()
+        self._make_tarball(tmpdir, name, '.tar.gz', compresslevel=9)
+        end_9 = perf_counter()
+        duration_9 = end_9 - start_9
+
+        assert duration_1 < duration_9, "level 1 must be faster than level 9"
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_make_tarball_gzip(self):
@@ -87,7 +102,7 @@ class ArchiveUtilTestCase(support.TempdirManager):
 
     def _make_tarball(self, tmpdir, target_name, suffix, **kwargs):
         tmpdir2 = self.mkdtemp()
-        if same_drive(tmpdir, tmpdir2):
+        if not same_drive(tmpdir, tmpdir2):
             pytest.skip("source and target should be on same drive")
 
         base_name = os.path.join(tmpdir2, target_name)


### PR DESCRIPTION
title mostly speaks for itself, but as for the why: I notice that `build -s` is taking a very long time and 90% of it is spent hugely optimizing the tarball as level 9 is the default, I would like to fine-tune that in setuptools, but first distutils needs to support passing it along to `tarfile.open`

while testing, I noticed that the entire `tets_archive_util` file was ignored when running `python3.14 -m pytest`, which seemed to be fixed when prefixing the class with Test like any other class in the directory, presumably some leftover from a different testing framework