### PR TITLE
Avoid mutating caller-provided export symbols

### DIFF
--- a/distutils/command/build_ext.py
+++ b/distutils/command/build_ext.py
@@ -757,7 +757,7 @@ class build_ext(Command):
 
         initfunc_name = "PyInit" + suffix
         if initfunc_name not in ext.export_symbols:
-            ext.export_symbols.append(initfunc_name)
+            ext.export_symbols = [*ext.export_symbols, initfunc_name]
         return ext.export_symbols
 
     def _get_module_name_for_symbol(self, ext):

--- a/distutils/tests/test_build_ext.py
+++ b/distutils/tests/test_build_ext.py
@@ -412,6 +412,20 @@ class TestBuildExt(TempdirManager):
         assert cmd.get_export_symbols(modules[0]) == ['PyInit_foo']
         assert cmd.get_export_symbols(modules[1]) == ['PyInitU_f_1gaa']
 
+    def test_export_symbols_does_not_mutate_input(self):
+        export_symbols = ['test_fn']
+        modules = [
+            Extension('foo.bar', ['bar.c'], export_symbols=export_symbols),
+            Extension('foo.baz', ['baz.c'], export_symbols=export_symbols),
+        ]
+        dist = Distribution({'name': 'xx', 'ext_modules': modules})
+        cmd = self.build_ext(dist)
+        cmd.ensure_finalized()
+
+        assert cmd.get_export_symbols(modules[0]) == ['test_fn', 'PyInit_bar']
+        assert cmd.get_export_symbols(modules[1]) == ['test_fn', 'PyInit_baz']
+        assert export_symbols == ['test_fn']
+
     def test_compiler_option(self):
         # cmd.compiler is an option and
         # should not be overridden by a compiler instance

--- a/newsfragments/+issue3058-export-symbols.bugfix.rst
+++ b/newsfragments/+issue3058-export-symbols.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid mutating a caller-provided ``Extension.export_symbols`` list when adding the module initialization symbol.


### PR DESCRIPTION
## Summary of changes

`build_ext.get_export_symbols` appended the generated `PyInit_*` symbol directly to `Extension.export_symbols`. Because `Extension` retains the caller's list, the symbol leaked into the caller and any sibling extensions sharing that list, which can make the second Windows link export the first module's initializer.

Rebind `ext.export_symbols` to a new list when the initializer is missing. This preserves the caller-provided symbols while keeping the generated initializer on the extension being built.

Fixes pypa/setuptools#3058

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in `newsfragments/`.

### Tests
- Focused regression: 6 passed
- Full functional suite (excluding two MinGW tests requiring unavailable `gcc`): 240 passed, 27 skipped, 2 xfailed
- Ruff format: passed
- Mypy for changed source: passed
- Towncrier draft: passed