### PR TITLE
Compiler registry via get_compilers; decouple compiler tests from distutils

### DIFF
--- a/distutils/ccompiler.py
+++ b/distutils/ccompiler.py
@@ -6,9 +6,9 @@ from .compilers.C import base
 from .compilers.C.base import (
     gen_lib_options,
     gen_preprocess_options,
+    get_compilers,
     get_default_compiler,
     new_compiler,
-    show_compilers,
 )
 from .compilers.C.errors import CompileError, LinkError
 
@@ -24,3 +24,19 @@ __all__ = [
 
 
 CCompiler = base.Compiler
+
+
+def show_compilers() -> None:
+    """Print list of available compilers (used by the "--help-compiler"
+    options to "build", "build_ext", "build_clib").
+    """
+    # XXX this "knows" that the compiler option it's describing is
+    # "--compiler", which just happens to be the case for the three
+    # commands that use it.
+    from .fancy_getopt import FancyGetopt
+
+    compilers = sorted(
+        ("compiler=" + name, None, cls.description)
+        for name, cls in get_compilers().items()
+    )
+    FancyGetopt(compilers).print_help("List of available compilers:")

--- a/distutils/compat/numpy.py
+++ b/distutils/compat/numpy.py
@@ -1,2 +1,23 @@
 # required for older numpy versions on Pythons prior to 3.12; see pypa/setuptools#4876
-from ..compilers.C.base import _default_compilers, compiler_class  # noqa: F401
+from ..compilers.C.base import _default_compilers  # noqa: F401
+
+# Map compiler short names to (module_name, class_name, description). Retained
+# for older numpy, which reads ``distutils.ccompiler.compiler_class``; the
+# compilers package itself now discovers compilers via
+# ``compilers.C.base.get_compilers()``.
+compiler_class = {
+    'unix': ('unixccompiler', 'UnixCCompiler', "standard UNIX-style compiler"),
+    'msvc': ('_msvccompiler', 'MSVCCompiler', "Microsoft Visual C++"),
+    'cygwin': (
+        'cygwinccompiler',
+        'CygwinCCompiler',
+        "Cygwin port of GNU C Compiler for Win32",
+    ),
+    'mingw32': (
+        'cygwinccompiler',
+        'Mingw32CCompiler',
+        "Mingw32 port of GNU C Compiler for Win32",
+    ),
+    'bcpp': ('bcppcompiler', 'BCPPCompiler', "Borland C++ Compiler"),
+    'zos': ('zosccompiler', 'zOSCCompiler', 'IBM XL C/C++ Compilers'),
+}

--- a/distutils/compilers/C/base.py
+++ b/distutils/compilers/C/base.py
@@ -62,11 +62,16 @@ class Compiler:
 
     compiler_type: ClassVar[str]
     """
-    Identify the kind of compiler, so callers can tell compilers apart
-    without importing every compiler class for an ``isinstance`` check.
-    Set this in each concrete subclass to one of the keys of
-    ``compiler_class`` (see below, used by ``new_compiler()``), and update
-    ``compiler_class`` to match.
+    Short name identifying the kind of compiler, so callers can tell
+    compilers apart without importing every compiler class for an
+    ``isinstance`` check. Set this in each concrete subclass; it's the key
+    under which the class is registered by ``get_compilers()``.
+    """
+
+    description: ClassVar[str]
+    """
+    Human-readable description of the compiler, shown by ``show_compilers()``.
+    Set this in each concrete subclass.
     """
 
     # XXX things not handled by this compiler abstraction model:
@@ -1254,42 +1259,28 @@ def get_default_compiler(osname: str | None = None, platform: str | None = None)
     return 'unix'
 
 
-# Map compiler types to (module_name, class_name) pairs -- ie. where to
-# find the code that implements an interface to this compiler.  (The module
-# is assumed to be in the 'distutils' package.)
-compiler_class = {
-    'unix': ('unixccompiler', 'UnixCCompiler', "standard UNIX-style compiler"),
-    'msvc': ('_msvccompiler', 'MSVCCompiler', "Microsoft Visual C++"),
-    'cygwin': (
-        'cygwinccompiler',
-        'CygwinCCompiler',
-        "Cygwin port of GNU C Compiler for Win32",
-    ),
-    'mingw32': (
-        'cygwinccompiler',
-        'Mingw32CCompiler',
-        "Mingw32 port of GNU C Compiler for Win32",
-    ),
-    'bcpp': ('bcppcompiler', 'BCPPCompiler', "Borland C++ Compiler"),
-    'zos': ('zosccompiler', 'zOSCCompiler', 'IBM XL C/C++ Compilers'),
-}
+def _concrete_compilers(cls: type[Compiler] | None = None):
+    """Yield every subclass of ``cls`` (recursively)."""
+    for subclass in (cls or Compiler).__subclasses__():
+        yield subclass
+        yield from _concrete_compilers(subclass)
 
 
-def show_compilers() -> None:
-    """Print list of available compilers (used by the "--help-compiler"
-    options to "build", "build_ext", "build_clib").
+def get_compilers() -> dict[str, type[Compiler]]:
+    """Map each compiler's short name (``compiler_type``) to its class.
+
+    Imports the concrete compiler modules so their classes are defined, then
+    collects every non-abstract ``Compiler`` subclass.
     """
-    # XXX this "knows" that the compiler option it's describing is
-    # "--compiler", which just happens to be the case for the three
-    # commands that use it.
-    from distutils.fancy_getopt import FancyGetopt
+    # ensure the concrete compiler classes are imported and thus registered
+    # as subclasses of Compiler
+    from . import cygwin, msvc, unix, zos  # noqa: F401
 
-    compilers = sorted(
-        ("compiler=" + compiler, None, compiler_class[compiler][2])
-        for compiler in compiler_class
-    )
-    pretty_printer = FancyGetopt(compilers)
-    pretty_printer.print_help("List of available compilers:")
+    return {
+        subclass.compiler_type: subclass
+        for subclass in _concrete_compilers()
+        if getattr(subclass, 'compiler_type', None)
+    }
 
 
 def new_compiler(
@@ -1298,7 +1289,7 @@ def new_compiler(
     verbose: bool = False,
     force: bool = False,
 ) -> Compiler:
-    """Generate an instance of some CCompiler subclass for the supplied
+    """Generate an instance of some Compiler subclass for the supplied
     platform/compiler combination.  'plat' defaults to 'os.name'
     (eg. 'posix', 'nt'), and 'compiler' defaults to the default compiler
     for that platform.  Currently only 'posix' and 'nt' are supported, and
@@ -1310,37 +1301,21 @@ def new_compiler(
     """
     if plat is None:
         plat = os.name
+    if compiler is None:
+        compiler = get_default_compiler(plat)
 
     try:
-        if compiler is None:
-            compiler = get_default_compiler(plat)
-
-        (module_name, class_name, _long_description) = compiler_class[compiler]
+        cls = get_compilers()[compiler]
     except KeyError:
         msg = f"don't know how to compile C/C++ code on platform '{plat}'"
         if compiler is not None:
             msg = msg + f" with '{compiler}' compiler"
         raise PlatformError(msg)
 
-    try:
-        module_name = "distutils." + module_name
-        __import__(module_name)
-        module = sys.modules[module_name]
-        klass = vars(module)[class_name]
-    except ImportError:
-        raise PlatformError(
-            f"can't compile C/C++ code: unable to load module '{module_name}'"
-        )
-    except KeyError:
-        raise PlatformError(
-            f"can't compile C/C++ code: unable to find class '{class_name}' "
-            f"in module '{module_name}'"
-        )
-
     # XXX The None is necessary to preserve backwards compatibility
     # with classes that expect verbose to be the first positional
     # argument.
-    return klass(None, force=force)
+    return cls(None, force=force)
 
 
 def gen_preprocess_options(

--- a/distutils/compilers/C/cygwin.py
+++ b/distutils/compilers/C/cygwin.py
@@ -43,6 +43,7 @@ class Compiler(unix.Compiler):
     """Handles the Cygwin port of the GNU C compiler to Windows."""
 
     compiler_type = 'cygwin'
+    description = "Cygwin port of GNU C Compiler for Win32"
     obj_extension = ".o"
     static_lib_extension = ".a"
     shared_lib_extension = ".dll.a"
@@ -245,6 +246,7 @@ class MinGW32Compiler(Compiler):
     """Handles the Mingw32 port of the GNU C compiler to Windows."""
 
     compiler_type = 'mingw32'
+    description = "Mingw32 port of GNU C Compiler for Win32"
 
     def __init__(self, verbose=False, force=False):
         super().__init__(verbose, force)

--- a/distutils/compilers/C/msvc.py
+++ b/distutils/compilers/C/msvc.py
@@ -297,6 +297,7 @@ class Compiler(base.Compiler):
     as defined by the CCompiler abstract class."""
 
     compiler_type = 'msvc'
+    description = "Microsoft Visual C++"
 
     # Just set this so CCompiler's constructor doesn't barf.  We currently
     # don't use the 'set_executables()' bureaucracy provided by CCompiler,

--- a/distutils/compilers/C/tests/conftest.py
+++ b/distutils/compilers/C/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.fixture
+def disable_macos_customization(monkeypatch):
+    from ...platform import macos
+
+    monkeypatch.setattr(macos, 'customize_compiler', lambda config_vars: None)

--- a/distutils/compilers/C/tests/test_cygwin.py
+++ b/distutils/compilers/C/tests/test_cygwin.py
@@ -1,9 +1,8 @@
-"""Tests for distutils.cygwinccompiler."""
+"""Tests for the Cygwin C compiler."""
 
 import os
 import sys
 import sysconfig
-from distutils.tests import support
 
 import pytest
 
@@ -11,23 +10,20 @@ from .. import cygwin
 
 
 @pytest.fixture(autouse=True)
-def stuff(request, monkeypatch, distutils_managed_tempdir):
+def stuff(request, monkeypatch, tmp_path):
     self = request.instance
-    self.python_h = os.path.join(self.mkdtemp(), 'python.h')
-    monkeypatch.setattr(sysconfig, 'get_config_h_filename', self._get_config_h_filename)
+    self.python_h = tmp_path / 'python.h'
+    monkeypatch.setattr(
+        sysconfig, 'get_config_h_filename', lambda: os.fspath(self.python_h)
+    )
     monkeypatch.setattr(sys, 'version', sys.version)
 
 
-class TestCygwinCCompiler(support.TempdirManager):
-    def _get_config_h_filename(self):
-        return self.python_h
-
+class TestCygwinCCompiler:
     @pytest.mark.skipif('sys.platform != "cygwin"')
     @pytest.mark.skipif('not os.path.exists("/usr/lib/libbash.dll.a")')
     def test_find_library_file(self):
-        from distutils.cygwinccompiler import CygwinCCompiler
-
-        compiler = CygwinCCompiler()
+        compiler = cygwin.Compiler()
         link_name = "bash"
         linkable_file = compiler.find_library_file(["/usr/lib"], link_name)
         assert linkable_file is not None
@@ -36,9 +32,7 @@ class TestCygwinCCompiler(support.TempdirManager):
 
     @pytest.mark.skipif('sys.platform != "cygwin"')
     def test_runtime_library_dir_option(self):
-        from distutils.cygwinccompiler import CygwinCCompiler
-
-        compiler = CygwinCCompiler()
+        compiler = cygwin.Compiler()
         assert compiler.runtime_library_dir_option('/foo') == []
 
     def test_check_config_h(self):
@@ -58,11 +52,11 @@ class TestCygwinCCompiler(support.TempdirManager):
         assert cygwin.check_config_h()[0] == cygwin.CONFIG_H_UNCERTAIN
 
         # if it exists but does not contain __GNUC__, it returns CONFIG_H_NOTOK
-        self.write_file(self.python_h, 'xxx')
+        self.python_h.write_text('xxx')
         assert cygwin.check_config_h()[0] == cygwin.CONFIG_H_NOTOK
 
         # and CONFIG_H_OK if __GNUC__ is found
-        self.write_file(self.python_h, 'xxx __GNUC__ xxx')
+        self.python_h.write_text('xxx __GNUC__ xxx')
         assert cygwin.check_config_h()[0] == cygwin.CONFIG_H_OK
 
     def test_get_msvcr(self):
@@ -70,7 +64,5 @@ class TestCygwinCCompiler(support.TempdirManager):
 
     @pytest.mark.skipif('sys.platform != "cygwin"')
     def test_dll_libraries_not_none(self):
-        from distutils.cygwinccompiler import CygwinCCompiler
-
-        compiler = CygwinCCompiler()
+        compiler = cygwin.Compiler()
         assert compiler.dll_libraries is not None

--- a/distutils/compilers/C/tests/test_mingw.py
+++ b/distutils/compilers/C/tests/test_mingw.py
@@ -1,10 +1,9 @@
-from distutils import sysconfig
-from distutils.compilers.errors import PlatformError
-from distutils.util import is_mingw, split_quoted
-
 import pytest
 
 from ... import errors
+from ..._util import split_quoted
+from ...errors import PlatformError
+from ...platform.detect import is_mingw
 from .. import cygwin
 
 
@@ -61,9 +60,9 @@ class TestMinGW32Compiler:
             cygwin.MinGW32Compiler()
 
     @pytest.mark.skipif('sys.platform == "cygwin"')
-    def test_customize_compiler_with_msvc_python(self):
+    def test_configure_system_with_msvc_python(self):
         # In case we have an MSVC Python build, but still want to use
-        # MinGW32Compiler, then customize_compiler() shouldn't fail at least.
+        # MinGW32Compiler, then configure_system() shouldn't fail at least.
         # https://github.com/pypa/setuptools/issues/4456
         compiler = cygwin.MinGW32Compiler()
-        sysconfig.customize_compiler(compiler)
+        compiler.configure_system()

--- a/distutils/compilers/C/tests/test_msvc.py
+++ b/distutils/compilers/C/tests/test_msvc.py
@@ -2,18 +2,17 @@ import os
 import sys
 import sysconfig
 import threading
-from distutils.compilers.errors import PlatformError
-from distutils.tests import support
-from distutils.util import get_platform
 
 import pytest
 
+from ...errors import PlatformError
+from ...platform.detect import get_platform
 from .. import msvc
 
 needs_winreg = pytest.mark.skipif('not hasattr(msvc, "winreg")')
 
 
-class Testmsvccompiler(support.TempdirManager):
+class Testmsvccompiler:
     def test_no_compiler(self, monkeypatch):
         # makes sure query_vcvarsall raises
         # a PlatformError if the compiler

--- a/distutils/compilers/C/tests/test_unix.py
+++ b/distutils/compilers/C/tests/test_unix.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import sysconfig
-from distutils.tests import support
 from unittest import mock
 
 import pytest
@@ -30,7 +29,7 @@ def compiler_wrapper(request):
     request.instance.cc = CompilerWrapper()
 
 
-class TestUnixCCompiler(support.TempdirManager):
+class TestUnixCCompiler:
     @pytest.mark.skipif('platform.system == "Windows"')
     def test_runtime_libdir_option(self):  # noqa: C901
         # Issue #5900; GitHub Issue #37
@@ -373,12 +372,12 @@ class TestUnixCCompiler(support.TempdirManager):
             self.cc.configure_system()
         assert self.cc.linker_so[0] == 'my_ld'
 
-    def test_has_function(self):
+    def test_has_function(self, monkeypatch, tmp_path):
         # Issue https://github.com/pypa/distutils/issues/64:
         # ensure that setting output_dir does not raise
         # FileNotFoundError: [Errno 2] No such file or directory: 'a.out'
         self.cc.output_dir = 'scratch'
-        os.chdir(self.mkdtemp())
+        monkeypatch.chdir(tmp_path)
         self.cc.has_function('abort')
 
     def test_find_library_file(self, monkeypatch):

--- a/distutils/compilers/C/unix.py
+++ b/distutils/compilers/C/unix.py
@@ -132,6 +132,7 @@ def _linker_params(linker_cmd, compiler_cmd):
 
 class Compiler(base.Compiler):
     compiler_type = 'unix'
+    description = "standard UNIX-style compiler"
 
     # These are used by CCompiler in two places: the constructor sets
     # instance attributes 'preprocessor', 'compiler', etc. from them, and

--- a/distutils/compilers/C/zos.py
+++ b/distutils/compilers/C/zos.py
@@ -104,6 +104,8 @@ _ld_args = {
 # But each compiler requires it's own specific options to build successfully,
 # though some of the options are common between them
 class Compiler(unix.Compiler):
+    compiler_type = 'zos'
+    description = "IBM XL C/C++ Compilers"
     src_extensions: ClassVar[list[str] | None] = [
         '.c',
         '.C',


### PR DESCRIPTION
Two pre-extraction tweaks toward a standalone `compilers.C`.

## 1. Discover compilers via `get_compilers()`; move `show_compilers` out

Replaces the static `compiler_class` registry (name → module/class/description tuples, with a dynamic `distutils.<module>` import in `new_compiler`) with an OO discovery:

- `compilers.C.base.get_compilers()` imports the concrete compiler modules and returns `{compiler_type: class}` for every non-abstract `Compiler` subclass.
- Each compiler carries its own short name (`compiler_type`) and `description` as class attributes. `zos` gains `compiler_type = 'zos'` (it was inheriting `unix`'s, which would collide) — safe, since dispatch is by class hierarchy now, not `compiler_type`.
- `new_compiler` resolves classes through `get_compilers()`, dropping the dynamic `distutils.<module>` import (and its distutils coupling).
- `show_compilers` is a CLI concern, so it moves to `distutils.ccompiler` (built from `get_compilers()` + `FancyGetopt`).
- `compiler_class` is retained in `distutils.compat.numpy` for older numpy (pypa/setuptools#4876).

## 2. Decouple the compiler tests from distutils

The C compiler tests no longer import anything from the `distutils` package:

- `distutils.tests.support.TempdirManager` → pytest `tmp_path`.
- error/platform/util helpers imported from the compilers package (`compilers.errors`, `compilers.platform.detect`, `compilers._util`) instead of `distutils.util`/`distutils.compilers.errors`.
- the compilers' own `cygwin.Compiler` instead of the `distutils.cygwinccompiler` shim; stdlib `sysconfig`; `compiler.configure_system()` instead of `sysconfig.customize_compiler`.
- a local `conftest.py` provides `disable_macos_customization`.

The only remaining non-relative dependency is CPython's `test.support` (`os_helper.EnvironmentVarGuard`) in `test_unix` — stdlib test infrastructure, not distutils; a candidate for a follow-up at extraction time.

## Verification

Full `tox` (ruff + mypy + tests): 573 passed, 20 skipped, `py: OK`. `get_compilers`/`new_compiler`/`show_compilers` smoke-tested; the compiler test suite runs with zero `distutils`-package imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
