### PR TITLE
Change `Distribution.package_dir` declared type for something mutable for setuptools

### DIFF
--- a/distutils/dist.py
+++ b/distutils/dist.py
@@ -251,7 +251,7 @@ Common commands: (see '--help-commands' for more)
         # Distribution as a convenience to the developer.
         self.packages: list[str] | None = None
         self.package_data: dict[str, list[str]] = {}
-        self.package_dir: Mapping[str, str] | None = None
+        self.package_dir: dict[str, str] | None = None
         self.py_modules: list[str] | None = None
         self.libraries: list[tuple[str, dict[str, Any]]] | None = None
         self.headers: list[str] | None = None


### PR DESCRIPTION
`Distribution.package_dir` is mutated in place by setuptools' auto-discovery, so keep it declared as a `dict` rather than a read-only `Mapping`.

Needed for https://github.com/pypa/setuptools/pull/4861